### PR TITLE
feat: protocol update to 1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,4 @@ repos:
   hooks:
   - id: mypy
     files: src
+    additional_dependencies: [numpy==1.20.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.7.4
+  rev: v2.10.0
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
@@ -37,7 +37,7 @@ repos:
     additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.812
   hooks:
   - id: mypy
     files: src

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,19 @@ per-file-ignores =
 
 [mypy]
 files = src
-pretty = True
 python_version = 3.6
 warn_unused_configs = True
-warn_unused_ignores = True
-strict=True # Can remove or replace with finer-grained control
 
-[mypy-numpy]
-ignore_missing_imports = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True

--- a/src/uhi/typing/plottable.py
+++ b/src/uhi/typing/plottable.py
@@ -10,7 +10,10 @@ MyPy will force you to only use items in the Protocol.
 """
 
 import sys
-from typing import Any, Iterable, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Iterator, Optional, Sequence, Tuple, TypeVar, Union
+
+# NumPy 1.20+ will work much, much better than previous versions when type checking
+import numpy as np
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
@@ -19,10 +22,7 @@ else:
     from typing import Protocol, runtime_checkable
 
 
-protocol_version = (1, 1)
-
-# from numpy.typing import ArrayLike # requires NumPy 1.20
-ArrayLike = Iterable[float]
+protocol_version = (1, 2)
 
 # Known kinds of histograms. A Producer can add Kinds not defined here; a
 # Consumer should check for known types if it matters. A simple plotter could
@@ -86,6 +86,11 @@ class PlottableAxisGeneric(Protocol[T]):
         Required to be sequence-like.
         """
 
+    def __iter__(self) -> Iterator[T]:
+        """
+        Useful element of a Sequence to include.
+        """
+
 
 PlottableAxisContinuous = PlottableAxisGeneric[Tuple[float, float]]
 PlottableAxisInt = PlottableAxisGeneric[int]
@@ -108,7 +113,7 @@ class PlottableHistogram(Protocol):
     # If this is included, it should return an array with flow bins added,
     # normal ordering.
 
-    def values(self) -> ArrayLike:
+    def values(self) -> np.ndarray:
         """
         Returns the accumulated values. The counts for simple histograms, the
         sum of weights for weighted histograms, the mean for profiles, etc.
@@ -117,7 +122,7 @@ class PlottableHistogram(Protocol):
         kind == "MEAN".
         """
 
-    def variances(self) -> Optional[ArrayLike]:
+    def variances(self) -> Optional[np.ndarray]:
         """
         Returns the estimated variance of the accumulated values. The sum of squared
         weights for weighted histograms, the variance of samples for profiles, etc.
@@ -132,7 +137,7 @@ class PlottableHistogram(Protocol):
         weighted if the weight variance was tracked by the implementation.
         """
 
-    def counts(self) -> Optional[ArrayLike]:
+    def counts(self) -> Optional[np.ndarray]:
         """
         Returns the number of entries in each bin for an unweighted
         histogram or profile and an effective number of entries (defined below)


### PR DESCRIPTION
Making this extend `Sequence[T]` turns out to be rather hard in Python 3.6; due to the fact Generic types in 3.6 were actually objects and not classes, you couldn't inherit from one. In 3.7, this was fixed by the addition of `__class_getitem__` and a few other things, so Generics really are just normal classes (literally - in 3.9+ the built in classes now work as Generics using this). See https://github.com/python/typing/issues/561. This is also a large part of why importing the typing module in 3.7+ is 7x faster, it's not making a bunch of objects anymore, just classes.


I've added the one really useful "Sequence" method here; we could add the rest (in which case, this really would become a Sequence, as a Protocol is just that - no need to subclass), but for now, it seems this is close enough, I think. It will simply downstream code.

This closes #10 and the most important part of, and closes #6.

- feat: add method to GenericAxes, return np.ndarray
- chore: pre-commit autoupdate
