### PR TITLE
fix: add missing test folder to sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 
+include = [ { path = "tests/**/*", format = "sdist" } ]
+
 
 [tool.poetry.dependencies]
 python = ">=3.6"


### PR DESCRIPTION
Add missing test folder, fixes the conda-forge recipe testing check, using method described in python-poetry/poetry#3797 (and hopefully in the docs eventually).

Also dropping the `__init__` from tests, tests shouldn't (normally) have an init, not sure why it's there.