### PR TITLE
feat: conversion of ROOT histograms to PlottableHistogram

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    needs: [pre-commit]
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +36,6 @@ jobs:
         include:
         - python-version: pypy-3.7
           runs-on: ubuntu-latest
-
 
     steps:
     - uses: actions/checkout@v2
@@ -47,16 +47,41 @@ jobs:
     - name: Install package
       run: python -m pip install .[test]
 
-    - name: Test package
+    - name: Test
       run: python -m pytest -ra
+
+  root:
+    name: ROOT test
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        environment-file: environment.yml
+
+    - name: Install package
+      run: pip install .
+
+    - name: Test root
+      run: pytest -ra tests/test_root.py
+
 
 
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    needs: [pre-commit]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Build sdist and wheel
       run: pipx run build

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: uhi
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - pytest
+  - root
+  - pytest
+  - boost-histogram

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def lint(session):
     Run the linter.
     """
     session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files")
+    session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
 @nox.session(python=ALL_PYTHONS)
@@ -26,7 +26,7 @@ def tests(session):
     Run the unit and regular tests.
     """
     session.install(".[test]")
-    session.run("pytest")
+    session.run("pytest", *session.posargs)
 
 
 @nox.session
@@ -63,3 +63,14 @@ def build(session):
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+@nox.session(venv_backend="conda")
+def root_tests(session):
+    """
+    Test against ROOT.
+    """
+
+    session.conda_install("--channel=conda-forge", "ROOT", "pytest", "boost-histogram")
+    session.install(".")
+    session.run("pytest", "tests/test_root.py")

--- a/src/uhi/numpy_plottable.py
+++ b/src/uhi/numpy_plottable.py
@@ -258,16 +258,16 @@ class ROOTPlottableHistogram:
             return self.values()
 
     def counts(self) -> np.ndarray:
-        if self.hasWeights:
-            sumw = self.values()
-            return np.divide(  # type: ignore
-                sumw ** 2,
-                self.variances(),
-                out=np.zeros_like(sumw, dtype=np.float64),
-                where=sumw != 0,
-            )
-        else:
+        if not self.hasWeights:
             return self.values()
+
+        sumw = self.values()
+        return np.divide(  # type: ignore
+            sumw ** 2,
+            self.variances(),
+            out=np.zeros_like(sumw, dtype=np.float64),
+            where=sumw != 0,
+        )
 
 
 if TYPE_CHECKING:

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,7 +1,39 @@
+import numpy as np
 import pytest
+from pytest import approx
+
+from uhi.numpy_plottable import ensure_plottable_histogram
 
 ROOT = pytest.importorskip("ROOT")
 
 
 def test_root_imported() -> None:
     assert ROOT.TString("hi") == "hi"
+
+
+def test_root_th1f_convert() -> None:
+    th = ROOT.TH1F("h1", "h1", 50, -2.5, 2.5)
+    th.FillRandom("gaus", 10000)
+    h = ensure_plottable_histogram(th)
+    assert all(th.GetBinContent(i + 1) == approx(iv) for i, iv in enumerate(h.values()))
+    assert all(
+        th.GetBinError(i + 1) == approx(ie)
+        for i, ie in enumerate(np.sqrt(h.variances()))  # type: ignore
+    )
+
+
+def test_root_th2f_convert() -> None:
+    th = ROOT.TH2F("h2", "h2", 50, -2.5, 2.5, 50, -2.5, 2.5)
+    _ = ROOT.TF2("xyg", "xygaus", -2.5, 2.5, -2.5, 2.5)
+    th.FillRandom("xyg", 10000)
+    h = ensure_plottable_histogram(th)
+    assert all(
+        th.GetBinContent(i + 1, j + 1) == approx(iv)
+        for i, row in enumerate(h.values())
+        for j, iv in enumerate(row)
+    )
+    assert all(
+        th.GetBinError(i + 1, j + 1) == approx(ie)
+        for i, row in enumerate(np.sqrt(h.variances()))  # type: ignore
+        for j, ie in enumerate(row)
+    )

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,7 @@
+import pytest
+
+ROOT = pytest.importorskip("ROOT")
+
+
+def test_root_imported() -> None:
+    assert ROOT.TString("hi") == "hi"


### PR DESCRIPTION
Tested for TH1F by comparing as follows:
```python
import ROOT
h = ROOT.TH1F("h1", "h1", 50, -2.5, 2.5)
h.FillRandom("gaus", 10000)
h.Draw()
from matplotlib import pyplot as plt
fig, ax = plt.subplots()
import mplhep
mplhep.histplot(h)
plt.show()
```
The conversion to numpy exploits the fact that TH1 inherits from TArray (which can directly be converted to a numpy array) for storing the counts, and the sums of squared weights is stored as another TArray (so most could be replaced by equivalent PyROOT pythonizations in the future).
For more-dimensional histograms I put `order="F"` in the reshape such that `.values()[i,j]` equals `.GetBinContent(i+1, j+1)`, but didn't test beyond that. Overflow bins are dropped.

CC @andrzejnovak