### PR TITLE
ci: update to Python 3.11 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.11-dev"]
+        python-version: ["3.6", "3.11"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos