### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ extend-ignore = [
   "PT004",  # Use underscore for non-returning fixture (use usefixture instead)
   "PT013",  # Incorrect import of pytest
 ]
-target-version = "py37"
 typing-modules = ["mypackage._compat.typing"]
 src = ["src"]
 unfixable = [


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos