### PR TITLE
feat: starting generic testing framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
         - numpy
         - pytest
         - importlib_resources
+        - boost-histogram
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -65,10 +65,10 @@ use for the slice edges is to be explicit on what part you are
 interested for the projection. So an explicit (non-empty) slice here
 will case the relevant flow bin to be excluded.
 
-``loc``, ``project``, and ``rebin`` all live inside the histogramming
-package (like boost-histogram), but are completely general and can be created by a
-user using an explicit API (below). ``underflow`` and ``overflow`` also
-follow a general API.
+``loc`` and ``rebin`` live inside the histogramming package (like
+boost-histogram), but are completely general and can be created by a user using
+an explicit API (below). ``underflow`` and ``overflow`` also follow a general
+API. ``sum`` is just the Python built-in sum function.
 
 One drawback of the syntax listed above is that it is hard to select an action
 to run on an axis or a few axes out of many. For this use case, you can pass a

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -76,7 +76,8 @@ API. ``sum`` is just the Python built-in sum function.
 One drawback of the syntax listed above is that it is hard to select an action
 to run on an axis or a few axes out of many. For this use case, you can pass a
 dictionary to the index, and that has the syntax ``{axis:action}``. The actions
-are slices, and follow the rules listed above. This looks like:
+are slices, and follow the rules listed above. All axes that are unmentioned are
+left alone, just like ``...`` or explicit ``:`` would do. This looks like:
 
 .. code:: python3
 
@@ -90,7 +91,7 @@ to recover the original slicing syntax inside the dict:
 
 .. code:: python3
 
-    s = bh.tag.Slicer()
+    s = uhi.tag.Slicer()
 
     h[{0: s[::rebin(2)]}]   # rebin axis 0 by two
     h[{1: s[0:loc(3.5)]}]   # slice axis 1 from 0 to the data coordinate 3.5
@@ -229,6 +230,19 @@ Solution:
 
 
 --------------
+
+Extensions
+----------
+
+Boost-histogram currently implements a few extra additions to this that
+are not yet required:
+
+* Passing ``sum`` directly acts as if it was given as the third argument
+  (the action).
+* The ``rebin`` tag can be passed directly, as well.
+
+The inner workings of ``rebin`` are being worked on, and will be updated
+here when they are finalized.
 
 Details
 -------

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -26,6 +26,8 @@ Access:
    v = h[loc(b) + 1] # Returns the bin above the one containing the value
    v = h[underflow]  # Underflow and overflow can be accessed with special tags
 
+Indexing works like Python, with ``IndexError`` thrown if you are out of range.
+
 Slicing:
 ^^^^^^^^
 
@@ -42,6 +44,7 @@ Slicing:
    v2 = h[0:len:sum]     #   removes under or overflow from the calculation
    h2 = h[v, a:b]        #   A single value v is like v:v+1:sum
    h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
+
 
 Setting
 ^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ log_cli_level = "INFO"
 
 
 [tool.mypy]
-files = "src"
+files = ["src", "tests"]
 python_version = "3.8"
 warn_unused_configs = true
 strict = true
@@ -130,3 +130,4 @@ isort.required-imports = ["from __future__ import annotations"]
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
 "tests/test_ensure.py" = ["NPY002"]
+"src/**" = ["PT"]

--- a/src/uhi/tag.py
+++ b/src/uhi/tag.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from .typing.plottable import PlottableAxis
 
-__all__ = ["Locator", "Overflow", "Slicer", "Underflow", "at", "loc"]
+__all__ = ["Locator", "Overflow", "Slicer", "Underflow", "at", "loc", "rebin"]
 
 
 def __dir__() -> list[str]:
@@ -63,6 +63,11 @@ class Locator:
             s += str(abs(self.offset))
         return s
 
+    if typing.TYPE_CHECKING:
+        # Type checkers think that this is required
+        def __index__(self) -> int:
+            return 42
+
 
 class loc(Locator):
     __slots__ = ("value",)
@@ -109,3 +114,21 @@ class at:
 
     def __call__(self, axis: PlottableAxis) -> int:  # noqa: ARG002
         return self.value
+
+
+class rebin:
+    """
+    When used in the step of a Histogram's slice, rebin(n) combines bins,
+    scaling their widths by a factor of n. If the number of bins is not
+    divisible by n, the remainder is added to the overflow bin.
+    """
+
+    def __init__(self, factor: int) -> None:
+        # Items with .factor are specially treated in boost-histogram,
+        # performing a high performance rebinning
+        self.factor = factor
+
+    if typing.TYPE_CHECKING:
+        # Type checkers think that this is required
+        def __index__(self) -> int:
+            return 42

--- a/src/uhi/tag.py
+++ b/src/uhi/tag.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import copy
+import typing
+from typing import Any
+
+from .typing.plottable import PlottableAxis
+
+__all__ = ["Locator", "Overflow", "Slicer", "Underflow", "at", "loc"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class Slicer:
+    """
+    This is a simple class to make slicing inside dictionaries simpler.
+    This is how it should be used:
+
+        s = uhi.tag.Slicer()
+
+        h[{0: s[::bh.rebin(2)]}]   # rebin axis 0 by two
+
+    """
+
+    def __getitem__(self, item: slice) -> slice:
+        return item
+
+
+T = typing.TypeVar("T", bound="Locator")
+
+
+class Locator:
+    __slots__ = ("offset",)
+    NAME = ""
+
+    def __init__(self, offset: int = 0) -> None:
+        if not isinstance(offset, int):
+            msg = "The offset must be an integer"  # type: ignore[unreachable]
+            raise ValueError(msg)
+
+        self.offset = offset
+
+    def __add__(self: T, offset: int) -> T:
+        other = copy.copy(self)
+        other.offset += offset
+        return other
+
+    def __sub__(self: T, offset: int) -> T:
+        other = copy.copy(self)
+        other.offset -= offset
+        return other
+
+    def _print_self_(self) -> str:
+        return ""
+
+    def __repr__(self) -> str:
+        s = self.NAME or self.__class__.__name__
+        s += self._print_self_()
+        if self.offset != 0:
+            s += " + " if self.offset > 0 else " - "
+            s += str(abs(self.offset))
+        return s
+
+
+class loc(Locator):
+    __slots__ = ("value",)
+
+    def __init__(self, value: str | float, offset: int = 0) -> None:
+        super().__init__(offset)
+        self.value = value
+
+    def _print_self_(self) -> str:
+        return f"({self.value})"
+
+    # TODO: clarify that .index() is required
+    def __call__(self, axis: Any) -> int:
+        return axis.index(self.value) + self.offset  # type: ignore[no-any-return]
+
+
+class Underflow(Locator):
+    __slots__ = ()
+    NAME = "underflow"
+
+    def __call__(self, axis: PlottableAxis) -> int:  # noqa: ARG002
+        return -1 + self.offset
+
+
+underflow = Underflow()
+
+
+class Overflow(Locator):
+    __slots__ = ()
+    NAME = "overflow"
+
+    def __call__(self, axis: PlottableAxis) -> int:
+        return len(axis) + self.offset
+
+
+overflow = Overflow()
+
+
+class at:
+    __slots__ = ("value",)
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __call__(self, axis: PlottableAxis) -> int:  # noqa: ARG002
+        return self.value

--- a/src/uhi/testing/indexing.py
+++ b/src/uhi/testing/indexing.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import abc
+import typing
+import unittest
+from typing import Any
+
+import uhi.tag
+
+T = typing.TypeVar("T", bound=Any)
+
+__all__ = ["Indexing"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class Indexing(typing.Generic[T], abc.ABC, unittest.TestCase):
+    """
+    This test requires histograms to be created first.
+
+    h1 and h3 are histograms created in the test suite.
+    h1 is a 1D histogram with 10 bins from 0 to 1. Each bin has 2 more than the
+    one before, starting with 0. The overflow bin has 1.
+
+    h3 is a 3D histogram with [2,5,10] bins. The contents are x+2y+3z, where x,
+    y, and z are the bin indices.
+    """
+
+    h1: T
+    h3: T
+    tag = uhi.tag
+
+    @staticmethod
+    @abc.abstractmethod
+    def make_histogram_1() -> T:
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def make_histogram_3() -> T:
+        pass
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.h1 = cls.make_histogram_1()
+        cls.h3 = cls.make_histogram_3()
+
+    def test_access_integer_1d(self) -> None:
+        for i in range(10):
+            with self.subTest(i=i):
+                self.assertEqual(self.h1[i], 2 * i)
+
+        with self.assertRaises(IndexError):
+            self.h1[10]
+
+        self.assertEqual(self.h1[-1], 18)
+
+    def test_access_integer_1d_flow(self) -> None:
+        self.assertEqual(self.h1[self.tag.overflow], 1)
+        self.assertEqual(self.h1[self.tag.underflow], 0)
+
+    def test_access_integer_3d(self) -> None:
+        for i in range(2):
+            for j in range(5):
+                for k in range(10):
+                    with self.subTest(i=i, j=j, k=k):
+                        self.assertEqual(self.h3[i, j, k], i + 2 * j + 3 * k)
+
+        with self.assertRaises(IndexError):
+            self.h3[2, 0, 0]
+        with self.assertRaises(IndexError):
+            self.h3[0, 5, 0]
+        with self.assertRaises(IndexError):
+            self.h3[0, 0, 10]
+
+        self.assertEqual(self.h3[-1, -1, -1], 36)
+
+    def test_access_loc_1d(self) -> None:
+        self.assertEqual(self.h1[self.tag.loc(0.05)], 0)
+        self.assertEqual(self.h1[self.tag.loc(0.15)], 2)
+        self.assertEqual(self.h1[self.tag.loc(0.95)], 18)
+        self.assertEqual(self.h1[self.tag.loc(-1)], 0)
+        self.assertEqual(self.h1[self.tag.loc(2)], 1)
+
+    def test_access_loc_3d(self) -> None:
+        self.assertEqual(
+            self.h3[self.tag.loc(0.5), self.tag.loc(0.5), self.tag.loc(0.5)], 0
+        )
+        self.assertEqual(
+            self.h3[self.tag.loc(0.5), self.tag.loc(1.5), self.tag.loc(0.5)], 2
+        )
+        self.assertEqual(
+            self.h3[self.tag.loc(0.5), self.tag.loc(4.5), self.tag.loc(9.5)], 35
+        )
+        self.assertEqual(
+            self.h3[self.tag.loc(-1), self.tag.loc(0.5), self.tag.loc(0.5)], 0
+        )
+
+    def test_access_loc_3d_mixed(self) -> None:
+        self.assertEqual(self.h3[self.tag.loc(0.5), 0, self.tag.loc(0.5)], 0)
+        self.assertEqual(self.h3[0, self.tag.loc(1.5), self.tag.loc(0.5)], 2)
+        self.assertEqual(self.h3[self.tag.loc(0.5), self.tag.loc(4.5), 9], 35)
+        self.assertEqual(self.h3[1, self.tag.loc(4.5), 9], 36)
+
+    def test_access_loc_addition(self) -> None:
+        self.assertEqual(self.h1[self.tag.loc(0.05) + 1], 2)
+        self.assertEqual(self.h1[self.tag.loc(0.55) + 2], 14)
+        self.assertEqual(self.h1[self.tag.loc(0.55) - 2], 6)
+
+    def test_slicing_all(self) -> None:
+        self.assertEqual(self.h1[:], self.h1)
+        self.assertEqual(self.h1[...], self.h1)
+        self.assertEqual(self.h3[:, :, :], self.h3)
+        self.assertEqual(self.h3[...], self.h3)
+        self.assertEqual(self.h3[:, ...], self.h3)
+        self.assertEqual(self.h3[..., :], self.h3)
+
+    def test_slicing_1d_closed(self) -> None:
+        h = self.h1[2:4]
+        self.assertEqual(h[self.tag.underflow], 2)
+        self.assertEqual(h[0], 4)
+        self.assertEqual(h[1], 6)
+        self.assertEqual(h[self.tag.overflow], 79)
+
+        with self.assertRaises(IndexError):
+            h[2]
+
+    def test_slicing_1d_open_upper(self) -> None:
+        h = self.h1[5:]
+        self.assertEqual(h[self.tag.underflow], 20)
+        self.assertEqual(h[0], 10)
+        self.assertEqual(h[4], 18)
+        self.assertEqual(h[self.tag.overflow], 1)
+        with self.assertRaises(IndexError):
+            h[5]
+
+    def test_slicing_1d_open_lower(self) -> None:
+        h = self.h1[:5]
+        self.assertEqual(h[self.tag.underflow], 0)
+        self.assertEqual(h[0], 0)
+        self.assertEqual(h[4], 8)
+        self.assertEqual(h[self.tag.overflow], 71)
+        with self.assertRaises(IndexError):
+            h[5]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import boost_histogram as bh
+import numpy as np
+
+import uhi.testing.indexing
+
+
+class TestAccess(uhi.testing.indexing.Indexing[bh.Histogram]):
+    @staticmethod
+    def make_histogram_1() -> bh.Histogram:
+        h1 = bh.Histogram(bh.axis.Regular(10, 0, 1))
+        h1[:] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+        h1[bh.overflow] = 1
+        return h1
+
+    @staticmethod
+    def make_histogram_3() -> bh.Histogram:
+        h3 = bh.Histogram(
+            bh.axis.Regular(2, 0, 2),
+            bh.axis.Regular(5, 0, 5),
+            bh.axis.Regular(10, 0, 10),
+        )
+        x, y, z = np.mgrid[0:2, 0:5, 0:10]
+        h3[...] = x + 2 * y + 3 * z
+        return h3
+
+
+class TestAccessBHTag(TestAccess):
+    tag = bh.tag

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -11,6 +11,7 @@ class TestAccess(uhi.testing.indexing.Indexing[bh.Histogram]):
     def make_histogram_1() -> bh.Histogram:
         h1 = bh.Histogram(bh.axis.Regular(10, 0, 1))
         h1[:] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+        h1[bh.underflow] = 3
         h1[bh.overflow] = 1
         return h1
 


### PR DESCRIPTION
Starting a generic testing helper framework. For a third party to test their implementation, they can subclass the provided UnitTest fixture and implement the required methods producing histograms.

Thoughts so far:

* I could make this a Mixin, which would workaround a possible issue with discovery if you import it directly into your test file instead of keeping a dotted name. But then typing is trickier, so I haven't done that (yet).
* I could provide the suggested data contents. I think this might ideally follow serialization.
* This uses unittest not just because that avoids a dependency, but also because pytest won't rewrite an assert that's not in a test file. It can be run with pytest and still prints nicely.

Closes #133.