### PR TITLE
fix: touch up serialization, add TypedDict

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -3,7 +3,7 @@
 :::{warning}
 
 Serialization is in draft currently. Once at least one implementation is ready,
-we will remove this warning and release UHI 0.5.
+we will remove this warning and release a new version of the UHI helper package.
 
 :::
 
@@ -49,12 +49,10 @@ The following axes types are supported:
 
 * `"regular"`: A regularly spaced set of even bins. Boost-histogram's "integer"
   axes maps to this axis as well. Has `upper`, `lower`, `bins`, `underflow`,
-  `overflow`, and `circular` properties. `circular` defaults to False if not
-  present.
+  `overflow`, and `circular` properties.
 * `"variable"`: A continuous axis defined by bins+1 edges. Has `edges`, which
   is either an in-line list of numbers or a string pointing to an out-of-band data source.
-  Also has `underflow`, `overflow`, and `circular` properties. `circular`
-  defaults to False if not present.
+  Also has `underflow`, `overflow`, and `circular` properties.
 * `"category_int"`: A list of integer bins, non-continuous. Has `categories`,
   which is an in-line list of integers. Also has `flow`.
 * `"category_str"`: A list of string bins. Has `categories`,
@@ -67,18 +65,18 @@ All axes support `metadata`, a string-valued dictionary of arbitrary, JSON-like 
 
 The following storages are supported:
 
-* `"int"`: A collection of integers. Boost-histogram's Int64 and AtomicInt64
-  map to this, and sometimes Unlimited.
+* `"int"`: A collection of integers. Boost-histogram's `Int64` and `AtomicInt64`
+  map to this, and sometimes `Unlimited`.
 * `"double"`: A collection of 64-bit floating point values. Boost-histogram's
-  Double storage maps to this, and sometimes Unlimited.
+  `Double` storage maps to this, and sometimes `Unlimited`.
 * `"weighted"`: A collection of two arrays of 64-bit floating point values,
-  `"value"` and `"variance"`. Boost-histogram's Weight storage maps to this.
+  `"value"` and `"variance"`. Boost-histogram's `Weight` storage maps to this.
 * `"mean"`: A collection of three arrays of 64-bit floating point values,
-  "count", "value", and "variance". Boost-histogram's Mean storage maps to
+  "`count"`, `"value"`, and `"variance"`. Boost-histogram's `Mean` storage maps to
   this.
 * `"weighted_mean"`: A collection of four arrays of 64-bit floating point
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
-  `"variances"`. Boost-histogram's WeighedMean storage maps to this.
+  `"variances"`. Boost-histogram's `WeighedMean` storage maps to this.
 
 ## CLI/API
 
@@ -98,6 +96,9 @@ uhi.schema.validate("some/file.json")
 
 Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
 and maybe more.
+
+For static typing, you can use `uhi.typing.serialization.Histogram` to get a
+`TypedDict` of the schema.
 
 ```{warning}
 

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -44,7 +44,7 @@
     "regular_axis": {
       "type": "object",
       "description": "An evenly spaced set of continuous bins.",
-      "required": ["type", "lower", "upper", "bins", "underflow", "overflow"],
+      "required": ["type", "lower", "upper", "bins", "underflow", "overflow", "circular"],
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "regular" },
@@ -76,7 +76,7 @@
     "variable_axis": {
       "type": "object",
       "description": "A variably spaced set of continuous bins.",
-      "required": ["type", "edges", "underflow", "overflow"],
+      "required": ["type", "edges", "underflow", "overflow", "circular"],
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "variable" },
@@ -200,7 +200,7 @@
       "required": ["type", "data"],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string", "const": "int" },
+        "type": { "type": "string", "const": "weighted" },
         "data": {
           "oneOf": [
             {
@@ -226,7 +226,7 @@
       "required": ["type", "data"],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string", "const": "int" },
+        "type": { "type": "string", "const": "mean" },
         "data": {
           "oneOf": [
             {
@@ -253,7 +253,7 @@
       "required": ["type", "data"],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string", "const": "int" },
+        "type": { "type": "string", "const": "weighted_mean" },
         "data": {
           "oneOf": [
             {

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal, TypedDict
+
+__all__ = [
+    "BooleanAxis",
+    "CategoryIntAxis",
+    "CategoryStrAxis",
+    "DoubleStorage",
+    "Histogram",
+    "IntStorage",
+    "MeanData",
+    "MeanStorage",
+    "RegularAxis",
+    "VariableAxis",
+    "WeighedData",
+    "WeightedMeanData",
+    "WeightedMeanStorage",
+    "WeightedStorage",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class _RequiredRegularAxis(TypedDict):
+    type: Literal["regular"]
+    lower: float
+    upper: float
+    bins: int
+    underflow: bool
+    overflow: bool
+    circular: bool
+
+
+class RegularAxis(_RequiredRegularAxis, total=False):
+    metadata: dict[str, Any]
+
+
+class _RequiredVariableAxis(TypedDict):
+    type: Literal["variable"]
+    edges: list[float] | str
+    underflow: bool
+    overflow: bool
+    circular: bool
+
+
+class VariableAxis(_RequiredVariableAxis, total=False):
+    metadata: dict[str, Any]
+
+
+class _RequiredCategoryStrAxis(TypedDict):
+    type: Literal["category_str"]
+    categories: list[str]
+    flow: bool
+
+
+class CategoryStrAxis(_RequiredCategoryStrAxis, total=False):
+    metadata: dict[str, Any]
+
+
+class _RequiredCategoryIntAxis(TypedDict):
+    type: Literal["category_int"]
+    categories: list[int]
+    flow: bool
+
+
+class CategoryIntAxis(_RequiredCategoryIntAxis, total=False):
+    metadata: dict[str, Any]
+
+
+class _RequiredBooleanAxis(TypedDict):
+    type: Literal["boolean"]
+
+
+class BooleanAxis(_RequiredBooleanAxis, total=False):
+    metadata: dict[str, Any]
+
+
+class IntStorage(TypedDict):
+    type: Literal["int"]
+    data: str | Sequence[int]
+
+
+class DoubleStorage(TypedDict):
+    type: Literal["double"]
+    data: str | Sequence[float]
+
+
+class WeighedData(TypedDict):
+    values: Sequence[float]
+    variances: Sequence[float]
+
+
+class WeightedStorage(TypedDict):
+    type: Literal["weighted"]
+    data: str | WeighedData
+
+
+class MeanData(TypedDict):
+    counts: Sequence[float]
+    values: Sequence[float]
+    variances: Sequence[float]
+
+
+class MeanStorage(TypedDict):
+    type: Literal["mean"]
+    data: str | MeanData
+
+
+class WeightedMeanData(TypedDict):
+    sum_of_weights: Sequence[float]
+    sum_of_weights_squared: Sequence[float]
+    values: Sequence[float]
+    variances: Sequence[float]
+
+
+class WeightedMeanStorage(TypedDict):
+    type: Literal["weighted_mean"]
+    data: str | WeightedMeanData
+
+
+class _RequiredHistogram(TypedDict):
+    axes: list[
+        RegularAxis | VariableAxis | CategoryStrAxis | CategoryIntAxis | BooleanAxis
+    ]
+    storage: (
+        IntStorage | DoubleStorage | WeightedStorage | MeanStorage | WeightedMeanStorage
+    )
+
+
+class Histogram(_RequiredHistogram, total=False):
+    metadata: dict[str, Any]

--- a/tests/resources/reg.json
+++ b/tests/resources/reg.json
@@ -22,7 +22,8 @@
         "upper": 5,
         "bins": 5,
         "underflow": true,
-        "overflow": true
+        "overflow": true,
+        "circular": false
       }
     ],
     "storage": { "type": "double", "data": "some/path/depends/on/format" }


### PR DESCRIPTION
One change:

* `circular` is now a required property. Simplified implementation; I don't think there's a need to make it optional for a new standard.

One fix:

* The storages had copy-paste errors in the schema.

And a feature:

* Added a TypedDict version of the schema.
