### PR TITLE
feat: use values for all types

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -65,9 +65,9 @@ All axes support `metadata`, a string-valued dictionary of arbitrary, JSON-like 
 
 The following storages are supported:
 
-* `"int"`: A collection of integers. Boost-histogram's `Int64` and `AtomicInt64`
+* `"int"`: A collection of integers under `"value"`. Boost-histogram's `Int64` and `AtomicInt64`
   map to this, and sometimes `Unlimited`.
-* `"double"`: A collection of 64-bit floating point values. Boost-histogram's
+* `"double"`: A collection of 64-bit floating point values under `"value"`. Boost-histogram's
   `Double` storage maps to this, and sometimes `Unlimited`.
 * `"weighted"`: A collection of two arrays of 64-bit floating point values,
   `"value"` and `"variance"`. Boost-histogram's `Weight` storage maps to this.

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -177,9 +177,16 @@
           "oneOf": [
             {
               "type": "string",
-              "description": "A path (URI?) to the integer bin data."
+              "description": "A path (URI?) to the floating point bin data."
             },
-            { "type": "array", "items": { "type": "integer" } }
+            {
+              "type": "object",
+              "required": ["values"],
+              "additionalProperties": false,
+              "properties": {
+                "values": { "type": "array", "items": { "type": "integer" } }
+              }
+            }
           ]
         }
       }
@@ -197,7 +204,14 @@
               "type": "string",
               "description": "A path (URI?) to the floating point bin data."
             },
-            { "type": "array", "items": { "type": "number" } }
+            {
+              "type": "object",
+              "required": ["values"],
+              "additionalProperties": false,
+              "properties": {
+                "values": { "type": "array", "items": { "type": "number" } }
+              }
+            }
           ]
         }
       }

--- a/tests/resources/reg.json
+++ b/tests/resources/reg.json
@@ -12,7 +12,7 @@
         "circular": false
       }
     ],
-    "storage": { "type": "int", "data": [1, 2, 3, 4, 5] }
+    "storage": { "type": "int", "data": {"values": [1, 2, 3, 4, 5]} }
   },
   "two": {
     "axes": [

--- a/tests/resources/reg.json
+++ b/tests/resources/reg.json
@@ -12,7 +12,7 @@
         "circular": false
       }
     ],
-    "storage": { "type": "int", "data": {"values": [1, 2, 3, 4, 5]} }
+    "storage": { "type": "int", "data": { "values": [1, 2, 3, 4, 5] } }
   },
   "two": {
     "axes": [


### PR DESCRIPTION
This modifies the schema to keep the types more consistent. When implementing it, I have to have if statements around this portion; it would be simpler if every storage had the same structure.

Now they all are structured as `storage/data/values`, instead of `storage/data` sometimes containing fields and sometimes not.

This is a change to the schema, so I'd like sign-offs from @hdembinski and @jpivarski. There will be a series of these based on my discussions with @pfackeldey today and my findings in https://github.com/scikit-hep/boost-histogram/pull/997, so I'm apologizing in advance for the noise! This one specifically will also have a followup.
