### PR TITLE
fix: drop Slicer for np.s_

### DIFF
--- a/docs/indexing+.rst
+++ b/docs/indexing+.rst
@@ -49,8 +49,6 @@ An optional extension to indexing is expected for histogram implementations that
 
 .. code:: python3
 
-    s = bh.tag.Slicer()
-
-    h[{"a": s[::2j]}]       # rebin axis "a" by two
-    h[{"x": s[0:3.5j]}]     # slice axis "x" from 0 to the data coordinate 3.5
-    h[{"other": s[0:2:4j]}] # slice and rebin axis "other"
+    h[{"a": np.s_[::2j]}]       # rebin axis "a" by two
+    h[{"x": np.s_[0:3.5j]}]     # slice axis "x" from 0 to the data coordinate 3.5
+    h[{"other": np.s_[0:2:4j]}] # slice and rebin axis "other"

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -86,17 +86,14 @@ left alone, just like ``...`` or explicit ``:`` would do. This looks like:
     h[{7: slice(0, 2, bh.rebin(4))}]       # slice and rebin axis 7
 
 
-If you don't like manually building slices, you can use the ``Slicer()`` utility
+If you don't like manually building slices, you can use the ``np.s_`` utility
 to recover the original slicing syntax inside the dict:
 
 .. code:: python3
 
-    s = uhi.tag.Slicer()
-
-    h[{0: s[::rebin(2)]}]   # rebin axis 0 by two
-    h[{1: s[0:loc(3.5)]}]   # slice axis 1 from 0 to the data coordinate 3.5
-    h[{7: s[0:2:rebin(4)]}] # slice and rebin axis 7
-
+    h[{0: np.s_[::rebin(2)]}]   # rebin axis 0 by two
+    h[{1: np.s_[0:loc(3.5)]}]   # slice axis 1 from 0 to the data coordinate 3.5
+    h[{7: np.s_[0:2:rebin(4)]}] # slice and rebin axis 7
 
 
 Invalid syntax:
@@ -211,8 +208,7 @@ shortcut to quickly generate slices is provided, as well:
    ans = h[{1: slice(None,bh.loc(2.4),bh.sum)}]
 
    # Identical:
-   s = bh.tag.Slicer()
-   ans = h[{1: s[:bh.loc(2.4):bh.sum]}]
+   ans = h[{1: np.s_[:bh.loc(2.4):bh.sum]}]
 
 Example 4:
 ^^^^^^^^^^

--- a/src/uhi/tag.py
+++ b/src/uhi/tag.py
@@ -6,26 +6,11 @@ from typing import Any
 
 from .typing.plottable import PlottableAxis
 
-__all__ = ["Locator", "Overflow", "Slicer", "Underflow", "at", "loc", "rebin"]
+__all__ = ["Locator", "Overflow", "Underflow", "at", "loc", "rebin"]
 
 
 def __dir__() -> list[str]:
     return __all__
-
-
-class Slicer:
-    """
-    This is a simple class to make slicing inside dictionaries simpler.
-    This is how it should be used:
-
-        s = uhi.tag.Slicer()
-
-        h[{0: s[::bh.rebin(2)]}]   # rebin axis 0 by two
-
-    """
-
-    def __getitem__(self, item: slice) -> slice:
-        return item
 
 
 T = typing.TypeVar("T", bound="Locator")

--- a/src/uhi/testing/indexing.py
+++ b/src/uhi/testing/indexing.py
@@ -287,8 +287,7 @@ class Indexing(typing.Generic[T], abc.ABC, unittest.TestCase):
             h[2]
 
     def test_mixed_single_integration_dict_3d(self) -> None:
-        s = self.tag.Slicer()
-        h = self.h3[{0: 1, 1: s[::sum], 2: s[1:3]}]
+        h = self.h3[{0: 1, 1: np.s_[::sum], 2: np.s_[1:3]}]
         self.assertEqual(h[0], 40)
         self.assertEqual(h[1], 55)
 
@@ -305,8 +304,7 @@ class Indexing(typing.Generic[T], abc.ABC, unittest.TestCase):
             h[5]
 
     def test_ellipsis_integration_dict_3d(self) -> None:
-        s = self.tag.Slicer()
-        h = self.h3[{0: s[::sum], 2: s[::sum]}]
+        h = self.h3[{0: np.s_[::sum], 2: np.s_[::sum]}]
         self.assertEqual(h[0], 280)
         self.assertEqual(h[1], 320)
         self.assertEqual(h[4], 440)
@@ -506,9 +504,7 @@ class Indexing(typing.Generic[T], abc.ABC, unittest.TestCase):
     def test_setting_dict_slicer_3d(self) -> None:
         h = self.make_histogram_3()
 
-        s = self.tag.Slicer()
-
-        h[{0: 1, 1: 0, 2: s[3:5]}] = range(42, 44)
+        h[{0: 1, 1: 0, 2: np.s_[3:5]}] = range(42, 44)
         self.assertEqual(h[1, 0, 2], 7)
         self.assertEqual(h[1, 0, 3], 42)
         self.assertEqual(h[1, 0, 4], 43)


### PR DESCRIPTION
This is in numpy, so let's drop it. `uhi.tag` is new and unreleased, so no need for back-compat (unlike boost-histogram).
