### PR TITLE
feat: add writer_info field

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -80,7 +80,7 @@ The following storages are supported:
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
   `"variances"`. Boost-histogram's `WeightedMean` storage maps to this.
 
-A library can fill the optional `"library"` field with a key specific to the
+A library can fill the optional `"writer_info"` field with a key specific to the
 library containing library specific metadata. There is one defined key,
 `"version"`, which contains the version of the library that created the
 histogram. Libraries should include this key when creating a histogram. It is
@@ -91,7 +91,7 @@ might contain:
 
 ```json
 {
-  "library": {
+  "writer_info": {
     "boost-histogram": {
       "version": "1.0.0",
     }

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -80,14 +80,14 @@ The following storages are supported:
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
   `"variances"`. Boost-histogram's `WeightedMean` storage maps to this.
 
-A library can fill the optional `"writer_info"` field with a key specific to the
-library containing library specific metadata. There is one defined key,
-`"version"`, which contains the version of the library that created the
-histogram. Libraries should include this key when creating a histogram. It is
-not required for reading histograms.  Histogram libraries can put custom
-metadata here that they can use to record province information or help with
-same-library round trips. For example, a histogram created with boost-histogram
-might contain:
+A library can fill the optional `"writer_info"` field with a key specific to
+the library containing library specific metadata anywhere a metadata field is
+allowed. There is one defined key at the Histogram level, `"version"`, which
+contains the version of the library that created the histogram. Libraries
+should include this key when creating a histogram. It is not required for
+reading histograms.  Histogram libraries can put custom metadata here that they
+can use to record province information or help with same-library round trips.
+For example, a histogram created with boost-histogram might contain:
 
 ```json
 {

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -80,6 +80,26 @@ The following storages are supported:
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
   `"variances"`. Boost-histogram's `WeightedMean` storage maps to this.
 
+A library can fill the optional `"library"` field with a key specific to the
+library containing library specific metadata. There is one defined key,
+`"version"`, which contains the version of the library that created the
+histogram. Libraries should include this key when creating a histogram. It is
+not required for reading histograms.  Histogram libraries can put custom
+metadata here that they can use to record province information or help with
+same-library round trips. For example, a histogram created with boost-histogram
+might contain:
+
+```json
+{
+  "library": {
+    "boost-histogram": {
+      "version": "1.0.0",
+    }
+  }
+  ...,
+}
+```
+
 ## CLI/API
 
 You can currently test a JSON file against the schema by running:

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -10,6 +10,23 @@
       "required": ["axes", "storage"],
       "additionalProperties": false,
       "properties": {
+        "library": {
+          "type": "object",
+          "description": "Information from the library that created the histogram.",
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "description": "Version of the library."
+                }
+              }
+            }
+          }
+        },
         "metadata": { "$ref": "#/$defs/metadata" },
         "axes": {
           "type": "array",

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -10,7 +10,7 @@
       "required": ["axes", "storage"],
       "additionalProperties": false,
       "properties": {
-        "library": {
+        "writer_info": {
           "type": "object",
           "description": "Information from the library that created the histogram.",
           "additionalProperties": false,

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -55,18 +55,27 @@
     }
   },
   "$defs": {
+    "supported_metadata": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" }
+      ]
+    },
     "metadata": {
       "type": "object",
       "description": "Arbitrary metadata dictionary.",
       "additionalProperties": false,
       "patternProperties": {
-        ".*": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "number" },
-            { "type": "boolean" }
-          ]
-        }
+        ".+": { "$ref": "#/$defs/supported_metadata" }
+      }
+    },
+    "writer_info": {
+      "type": "object",
+      "description": "Information from the library that created the histogram.",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".+": { "$ref": "#/$defs/supported_metadata" }
       }
     },
     "data_array": {
@@ -115,7 +124,8 @@
           "type": "boolean",
           "description": "True if the axis wraps around."
         },
-        "metadata": { "$ref": "#/$defs/metadata" }
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "writer_info": { "$ref": "#/$defs/writer_info" }
       }
     },
     "variable_axis": {
@@ -140,7 +150,8 @@
         "underflow": { "type": "boolean" },
         "overflow": { "type": "boolean" },
         "circular": { "type": "boolean" },
-        "metadata": { "$ref": "#/$defs/metadata" }
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "writer_info": { "$ref": "#/$defs/writer_info" }
       }
     },
     "category_str_axis": {
@@ -159,7 +170,8 @@
           "type": "boolean",
           "description": "True if flow bin (at the overflow position) present."
         },
-        "metadata": { "$ref": "#/$defs/metadata" }
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "writer_info": { "$ref": "#/$defs/writer_info" }
       }
     },
     "category_int_axis": {
@@ -178,7 +190,8 @@
           "type": "boolean",
           "description": "True if flow bin (at the overflow position) present."
         },
-        "metadata": { "$ref": "#/$defs/metadata" }
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "writer_info": { "$ref": "#/$defs/writer_info" }
       }
     },
     "boolean_axis": {
@@ -188,7 +201,8 @@
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "boolean" },
-        "metadata": { "$ref": "#/$defs/metadata" }
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "writer_info": { "$ref": "#/$defs/writer_info" }
       }
     },
     "int_storage": {

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -36,6 +36,7 @@ class _RequiredRegularAxis(TypedDict):
 
 class RegularAxis(_RequiredRegularAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]
 
 
 class _RequiredVariableAxis(TypedDict):
@@ -48,6 +49,7 @@ class _RequiredVariableAxis(TypedDict):
 
 class VariableAxis(_RequiredVariableAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]
 
 
 class _RequiredCategoryStrAxis(TypedDict):
@@ -58,6 +60,7 @@ class _RequiredCategoryStrAxis(TypedDict):
 
 class CategoryStrAxis(_RequiredCategoryStrAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]
 
 
 class _RequiredCategoryIntAxis(TypedDict):
@@ -68,6 +71,7 @@ class _RequiredCategoryIntAxis(TypedDict):
 
 class CategoryIntAxis(_RequiredCategoryIntAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]
 
 
 class _RequiredBooleanAxis(TypedDict):
@@ -76,6 +80,7 @@ class _RequiredBooleanAxis(TypedDict):
 
 class BooleanAxis(_RequiredBooleanAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]
 
 
 class IntStorage(TypedDict):
@@ -120,3 +125,4 @@ class _RequiredHistogram(TypedDict):
 
 class Histogram(_RequiredHistogram, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, SupportedMetadata]

--- a/tests/resources/valid/reg.json
+++ b/tests/resources/valid/reg.json
@@ -15,6 +15,12 @@
     "storage": { "type": "int", "values": [1, 2, 3, 4, 5] }
   },
   "two": {
+    "library": {
+      "uhi": {
+        "version": "1.0.0",
+        "other_info": "Something"
+      }
+    },
     "axes": [
       {
         "type": "regular",

--- a/tests/resources/valid/reg.json
+++ b/tests/resources/valid/reg.json
@@ -15,7 +15,7 @@
     "storage": { "type": "int", "values": [1, 2, 3, 4, 5] }
   },
   "two": {
-    "library": {
+    "writer_info": {
       "uhi": {
         "version": "1.0.0",
         "other_info": "Something"


### PR DESCRIPTION
This adds a place for library-specific metadata to be added. This allows the library and version to be recorded in the histogram. It is not required for reading.

We floated around several ideas for this name; I thought of `"vendor"` (it's was inspired by the vendor field in CMakePreset.json), and we also considered `"header"`. But since we decided to make the histogram library a key, then `"library"` seems to be fitting. Open to suggestions, though. `"writer_info"` is another option.
