### PR TITLE
feat: zarr v3 read & write methods

### DIFF
--- a/src/uhi/io/zarr.py
+++ b/src/uhi/io/zarr.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+import zarr
+import numpy as np
+import numcodecs
+
+from ..typing.serialization import AnyAxis, AnyHistogram, AnyStorage, Histogram
+from . import ARRAY_KEYS
+
+__all__ = ["read", "write"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def write(grp: zarr.Group, /, histogram: AnyHistogram) -> None:
+    """
+    Write a histogram to a Zarr group.
+    """
+    # All referenced objects will be stored inside of /{name}/axes
+    hist_folder_storage = grp.create_group("axes")
+
+    # Metadata
+
+    if "metadata" in histogram:
+        metadata_grp = grp.create_group("metadata")
+        for key, val1 in histogram["metadata"].items():
+            metadata_grp.attrs[key] = val1
+
+    # Axes
+    for i, axis in enumerate(histogram["axes"]):
+        # Iterating through the axes, calling `create_axes_object` for each of them,
+        # creating references to new groups and appending it to the `items` dataset defined above
+        ax_group = hist_folder_storage.create_group(f"axis_{i}")
+        ax_info = axis.copy()
+        ax_metadata = ax_info.pop("metadata", None)
+        ax_edges_raw = ax_info.pop("edges", None)
+        ax_edges = np.asarray(ax_edges_raw) if ax_edges_raw is not None else None
+        ax_cats: list[int] | list[str] | None = ax_info.pop("categories", None)
+        for key, val2 in ax_info.items():
+            ax_group.attrs[key] = val2
+        if ax_metadata is not None:
+            ax_metadata_grp = ax_group.create_group("metadata")
+            for k, v in ax_metadata.items():
+                ax_metadata_grp.attrs[k] = v
+        if ax_edges is not None:
+            arr = ax_group.create_array("edges", shape=ax_edges.shape, dtype=ax_edges.dtype)
+            arr[:] = ax_edges
+        if ax_cats is not None:
+            # zarr v3 doesn't support str dtype yet, so we attach it to attrs (which should be ok in general)
+            ax_group.attrs["categories"] = ax_cats
+
+    # Storage
+    storage_grp = grp.create_group("storage")
+    storage_type = histogram["storage"]["type"]
+
+    storage_grp.attrs["type"] = storage_type
+
+    for key, val3 in histogram["storage"].items():
+        if key == "type":
+            continue
+        npvalue = np.asarray(val3)
+        arr = storage_grp.create_array(key, shape=npvalue.shape, dtype=npvalue.dtype)
+        arr[:] = npvalue
+
+
+def _convert_axes(group: zarr.Group | zarr.Dataset | zarr.Datatype) -> AnyAxis:
+    """
+    Convert a Zarr axis reference to a dictionary.
+    """
+    axis = {k: _convert_item(k, v) for k, v in group.attrs.items()}
+    if "edges" in group:
+        edges = group["edges"]
+        assert isinstance(edges, zarr.Array)
+        axis["edges"] = np.asarray(edges)
+    if "categories" in group.attrs:
+        categories = group.attrs["categories"]
+        axis["categories"] = [_convert_item("", c) for c in categories]
+
+    return axis  # type: ignore[return-value]
+
+
+def _convert_item(name: str, item: Any, /) -> Any:
+    """
+    Convert an HDF5 item to a native Python type.
+    """
+    if isinstance(item, bytes):
+        return item.decode("utf-8")
+    if name == "metadata":
+        return {k: _convert_item("", v) for k, v in item.items()}
+    if name in ARRAY_KEYS:
+        return item
+    if isinstance(item, np.generic):
+        return item.item()
+    return item
+
+
+def read(grp: zarr.Group, /) -> Histogram:
+    """
+    Read a histogram from a Zarr group.
+    """
+    axes_grp = grp["axes"]
+    assert isinstance(axes_grp, zarr.Group)
+
+    axes = [_convert_axes(axes_grp[ax]) for ax in sorted(axes_grp)]
+
+    storage_grp = grp["storage"]
+    assert isinstance(storage_grp, zarr.Group)
+    storage = AnyStorage(type=storage_grp.attrs["type"])
+    for key in storage_grp:
+        storage[key] = np.asarray(storage_grp[key])  # type: ignore[literal-required]
+
+    histogram_dict = AnyHistogram(axes=axes, storage=storage)
+    if "metadata" in grp:
+        histogram_dict["metadata"] = _convert_item("metadata", grp["metadata"].attrs)
+
+    return histogram_dict  # type: ignore[return-value]

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import uhi.io.json
+
+zarr = pytest.importorskip("zarr", reason="zarr is not installed")
+uhi_io_zarr = pytest.importorskip("uhi.io.zarr")
+
+DIR = Path(__file__).parent.resolve()
+
+VALID_FILES = DIR.glob("resources/valid/*.json")
+
+
+@pytest.mark.parametrize("filename", VALID_FILES, ids=lambda p: p.name)
+def test_valid_json(filename: Path, tmp_path: Path) -> None:
+    data = filename.read_text(encoding="utf-8")
+    hists = json.loads(data, object_hook=uhi.io.json.object_hook)
+
+    tmp_file = tmp_path / "test.zarr"
+
+    zarr_file = zarr.open(tmp_file, mode="w")
+    for name, hist in hists.items():
+        uhi_io_zarr.write(zarr_file.create_group(name), hist)
+
+    zarr_file = zarr.open(tmp_file, mode="r")
+    rehists = {name: uhi_io_zarr.read(zarr_file[name]) for name in hists}
+
+    assert hists.keys() == rehists.keys()
+
+    for name in hists:
+        hist = hists[name]
+        rehist = rehists[name]
+
+        # this is metadata, which is we can't compare against
+        hist.pop("writer_info", None)
+
+        # Check that the JSON representation is the same
+        data = json.dumps(hist, default=uhi.io.json.default, sort_keys=True)
+        redata = json.dumps(rehist, default=uhi.io.json.default, sort_keys=True)
+        
+        assert redata.replace(" ", "").replace("\n", "") == data.replace(
+            " ", ""
+        ).replace("\n", "")
+
+
+def test_reg_load(tmp_path: Path) -> None:
+    data = DIR / "resources/valid/reg.json"
+    hists = json.loads(
+        data.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+
+    tmp_file = tmp_path / "test.zarr"
+    zarr_file = zarr.open(tmp_file, mode="w")
+    uhi_io_zarr.write(zarr_file.create_group("one"), hists["one"])
+
+    zarr_file = zarr.open(tmp_file, mode="r")
+    one = uhi_io_zarr.read(zarr_file["one"])
+
+    assert one["metadata"] == {"one": True, "two": 2, "three": "three"}
+
+    assert len(one["axes"]) == 1
+    assert one["axes"][0]["type"] == "regular"
+    assert one["axes"][0]["lower"] == pytest.approx(0)
+    assert one["axes"][0]["upper"] == pytest.approx(5)
+    assert one["axes"][0]["bins"] == 3
+    assert one["axes"][0]["underflow"]
+    assert one["axes"][0]["overflow"]
+    assert not one["axes"][0]["circular"]
+
+    assert one["storage"]["type"] == "int"
+    assert one["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5])


### PR DESCRIPTION
This is in draft mode because I need to understand:
- should we use a deterministic chunking?
- why is the `writer_info` metadata not preserved? Is it supposed to be like that?


Also, the current implementation is based on zarr spec `v3.0.*`, will update once `v3.1` is out with string serialization support (then we can avoid storing cat ax names in `attrs`).