### PR TITLE
feat: add uhi_schema, lots of fixes

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,11 +1,5 @@
 # Serialization
 
-:::{warning}
-
-Serialization is in draft currently. Once at least one implementation is ready,
-we will remove this warning and release a new version of the UHI helper package.
-
-:::
 
 ## Introduction
 
@@ -13,19 +7,20 @@ Histogram serialization has to cover a wide range of formats. As such, we
 describe a form for serialization that covers the metadata structure as
 JSON-like, with a provided JSON-schema. The data (bins and/or variable edges)
 is stored out-of-band in a binary format based on what type of data file you
-are in.  For very small (primarily 1D) histograms, data is allowed inline as
+are in. For very small (primarily 1D) histograms, data is allowed inline as
 well.
 
 The following formats are being targeted:
 
 ```
-┌────────┐ ┌────────┐ ┌───────┐
-│  ROOT  │ │  HDF5  │ │  ZIP  │
-└────────┘ └────────┘ └───────┘
+┌──────────────┐ ┌────────┐ ┌────────────┐
+│  ROOT (todo) │ │  HDF5  │ │  ZIP/JSON  │
+└──────────────┘ └────────┘ └────────────┘
 ```
 
 Other formats can be used as well, assuming they support out-of-band data and
-text attributes or files for the metadata.
+text attributes or files for the metadata. We are working on a Zarr backend in
+the near future.
 
 ## Caveats
 
@@ -35,9 +30,10 @@ limitations are required:
 
 * Serialization followed by deserialisation may cause axis changes. Axis types
   may change to an equivalent but less performant axis, growth status will be
-  lost, etc.
-* Metadata must be expressible as JSON. It should also be reasonably sized; some
-  formats like HDF5 may limit the size of attributes to 64K.
+  lost, etc. Libraries can record custom `"writer_info"` attributes to improve
+  round trips, but histograms must always be openable without the extra info.
+* Metadata should also be reasonably sized; some formats like HDF5 may limit
+  the size of attributes to 64K.
 * Floating point errors could be incurred on conversion, as the storage format
   uses a stable but different representation.
 * Axis `name` is only part of the metadata, and is not standardized. This is
@@ -100,6 +96,13 @@ For example, a histogram created with boost-histogram might contain:
 }
 ```
 
+There is one more required top-level key: `"uhi_schema"`, which must be set to
+1 currently. If there is a future revision with a backward incompatible change,
+this will be bumped to 2, and readers should always error on future schemas,
+and support all older schemas. This is hoped to be unlikely/rare, but this also
+serves as a check that this is in fact a uhi serialization object. Non-breaking
+changes like additions are allowed without bumping the schema.
+
 ## CLI/API
 
 You can currently test a JSON file against the schema by running:
@@ -122,26 +125,122 @@ uhi.schema.validate(data)
 Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
 and maybe more.
 
-For static typing, you can use `uhi.typing.serialization.Histogram` to get a
-`TypedDict` of the schema.
 
-```{warning}
+## Format specific details and helpers
 
-Currently, this spec describes **how to prepare the metadata** for one of the
-targeted backends. It does not yet cover backend specific details, like how to
-define and use the binary resource locator strings or how to store the data.
-JSON is not a target spec, but just part of the ZIP spec, meaning the files
-that currently "pass" the tool above would be valid inside a `.zip` file
-eventually, but are not valid by themselves.
+The `uhi` library contains reference implementations of target formats. You can
+implement these yourself, but if you are using or have access to Python, feel
+free to use `uhi` if that helps.
+
+If an object has a `_to_uhi_` method, that will be used to convert it to a
+dictionary following the schema. A `_from_uhi_` classmethod is also
+recommended; however, this is generally part of the histogram constructor; if a
+UHI object is passed, it should be converted automatically.
+
+### JSON
+
+The simplest format, useful for writing tests. The JSON version is nearly
+identical to the intermediate representation; the only difference is that data
+is stored as nested lists. It is not intended for large histograms; the ZIP
+format (below) is nearly identical and builds on this with out-of-band data.
+
+Two utilities are provided; `uhi.io.json.default` and
+`uhi.io.json.object_hook`. These are used with Python's built-in json module to
+handle conversions.
+
+```python
+import json
+import uhi.io.json
+
+ob = json.dumps(h, default=uhi.io.json.default)
+uhi_hist = json.loads(ob, object_hook=uhi.io.json.object_hook)
 ```
 
-## Rendered schema
+Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
+representation,`ob` is a JSON string, and `uhi_hist` is an intermediate
+representation; you can pass it to `boost_histogram.Histogram` or `hist.Hist`.
+
+
+### ZIP
+
+The zip format is very similar to JSON, but stores data in the numpy zip format.
+Arrays are replaced by strings, which represent the `.npy` file inside the zip file
+containing the array. The names are arbitrary; see the uhi code if you want to see
+how uhi creates names. The metadata is in a file with the name of the histogram and
+a `.json` extension.
+
+We provide `uhi.io.json.write` and `uhi.io.json.read`, which work with open zip
+files from the standard library (or probably anything with a similar API).
+
+```python
+import zip
+import uhi.io.zip
+
+with zip.open("myfile.zip", "w") as z:
+    uhi.io.zip.write(zip_file, "histogram", h)
+
+with zip.open("myfile.zip", "r") as z:
+    h2 = uhi.io.zip.read(zip_file, "histogram")
+```
+
+Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
+representation, and`uhi_hist` is an intermediate representation; you can pass
+it to `boost_histogram.Histogram` or `hist.Hist`. The metadata name in the file
+is `"histogram.json"`. The contents of that file are identical to the JSON
+format, except arrays are replaced by string names to files inside the zipfile.
+
+### HDF5
+
+The HDF5 format is ideal for combining histograms with other data. You need the
+`h5py` library installed too to use this format. There is some extra structure
+here compared to the other formats. The groups are `"axes"`, `"ref_axes"`,
+`"metadata"`, and `"storage"`. Arrays for the axes are placed in `"ref_axes"`,
+since hdf5 doesn't have lists of arrays. Storage arrays are in-place. A
+Reference type is used to link the axes array with the data. "`edges"` and
+`"categories"` are datasets; the other axes values are attributes (or groups
+with attributes, like `"metadata"` and `"writer_info"`, which is a nested
+group).
+
+Likewise, the `"storage"` group sets `"type"` as an attribute, the others are
+datasets.
+
+We provide `uhi.io.hdf5.read` and `uhi.io.hdf5.write` to write to an open
+group.  The structure is relative; you can place it anywhere inside a hdf5
+file.
+
+```python
+with h5py.File("myfile.hdf5", "w") as h5_file:
+    uhi.io.hdf5.write(h5_file.create_group("histogram"), h)
+
+with h5py.File("myfile.hdf5", "r") as h5_file:
+    h2 = uhi.io.hdf5.read(h5_file["histogram"])
+```
+
+Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
+representation, and`uhi_hist` is an intermediate representation; you can pass
+it to `boost_histogram.Histogram` or `hist.Hist`. You should create the group
+you want the histogram to be in.
+
+<!-- TODO: make sure writer_info is stored, and make sure it's a nested group (via schema too) -->
+
+### ROOT
+
+ROOT files are not yet implemented.
+
+## Schema
+
+A typing helper `Histogram` is provided in `uhi.typing.serialization` as a
+`TypedDict`. The schema, provided in `resources` as `histogram.schema.json`,
+also allows strings for data members, since some formats (like ZIP) put data
+into an optimized location and specify a reference to them.
+
+### Rendered schema
 
 ```{jsonschema} ../src/uhi/resources/histogram.schema.json
 ```
 
 
-## Full schema
+### Full schema
 
 The full schema is below:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ log_cli_level = "INFO"
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 strict = true
 warn_unreachable = true

--- a/src/uhi/io/_common.py
+++ b/src/uhi/io/_common.py
@@ -1,0 +1,21 @@
+"""
+Common helpers for the different formats.
+"""
+
+from __future__ import annotations
+
+__all__ = ["_check_uhi_schema_version", "_convert_input"]
+
+from ..typing.serialization import AnyHistogram, ToUHIHistogram
+
+
+def _check_uhi_schema_version(uhi_schema: int, /) -> None:
+    if uhi_schema != 1:
+        msg = "Only uhi_schema=1 supported in this uhi version. Please update uhi."
+        raise TypeError(msg)
+
+
+def _convert_input(hist: AnyHistogram | ToUHIHistogram, /) -> AnyHistogram:
+    any_hist = hist._to_uhi_() if isinstance(hist, ToUHIHistogram) else hist
+    _check_uhi_schema_version(any_hist["uhi_schema"])
+    return any_hist  # type: ignore[return-value]

--- a/src/uhi/io/hdf5.py
+++ b/src/uhi/io/hdf5.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import typing
 from typing import Any
 
 import h5py
 import numpy as np
 
-from ..typing.serialization import AnyAxis, AnyHistogram, AnyStorage, Histogram
+from ..typing.serialization import (
+    AnyAxis,
+    AnyHistogram,
+    AnyStorage,
+    Histogram,
+    SupportedMetadata,
+    ToUHIHistogram,
+)
 from . import ARRAY_KEYS
+from ._common import _check_uhi_schema_version, _convert_input
 
 __all__ = ["read", "write"]
 
@@ -15,19 +24,40 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def write(grp: h5py.Group, /, histogram: AnyHistogram) -> None:
+def _handle_metadata_writer_info(
+    grp: h5py.Group,
+    metadata: dict[str, SupportedMetadata] | None,
+    writer_info: dict[str, dict[str, SupportedMetadata]] | None,
+) -> None:
+    # Metadata
+    if metadata:
+        metadata_grp = grp.create_group("metadata")
+        for key, val1 in metadata.items():
+            metadata_grp.attrs[key] = val1
+
+    # Writer info
+    if writer_info:
+        writer_info_grp = grp.create_group("writer_info")
+        for key, value in writer_info.items():
+            inner_wi_grp = writer_info_grp.create_group(key)
+            for k, v in value.items():
+                inner_wi_grp.attrs[k] = v
+
+
+def write(grp: h5py.Group, /, histogram: AnyHistogram | ToUHIHistogram) -> None:
     """
     Write a histogram to an HDF5 group.
     """
+    histogram = _convert_input(histogram)
     # All referenced objects will be stored inside of /{name}/ref_axes
     hist_folder_storage = grp.create_group("ref_axes")
 
-    # Metadata
+    # UHI version number
+    grp.attrs["uhi_schema"] = histogram["uhi_schema"]
 
-    if "metadata" in histogram:
-        metadata_grp = grp.create_group("metadata")
-        for key, val1 in histogram["metadata"].items():
-            metadata_grp.attrs[key] = val1
+    _handle_metadata_writer_info(
+        grp, histogram.get("metadata"), histogram.get("writer_info")
+    )
 
     # Axes
     axes_dataset = grp.create_dataset(
@@ -38,16 +68,14 @@ def write(grp: h5py.Group, /, histogram: AnyHistogram) -> None:
         # creating references to new groups and appending it to the `items` dataset defined above
         ax_group = hist_folder_storage.create_group(f"axis_{i}")
         ax_info = axis.copy()
-        ax_metadata = ax_info.pop("metadata", None)
         ax_edges_raw = ax_info.pop("edges", None)
         ax_edges = np.asarray(ax_edges_raw) if ax_edges_raw is not None else None
         ax_cats: list[int] | list[str] | None = ax_info.pop("categories", None)
+        _handle_metadata_writer_info(
+            ax_group, ax_info.pop("metadata", None), ax_info.pop("writer_info", None)
+        )
         for key, val2 in ax_info.items():
             ax_group.attrs[key] = val2
-        if ax_metadata is not None:
-            ax_metadata_grp = ax_group.create_group("metadata")
-            for k, v in ax_metadata.items():
-                ax_metadata_grp.attrs[k] = v
         if ax_edges is not None:
             ax_group.create_dataset("edges", shape=ax_edges.shape, data=ax_edges)
         if ax_cats is not None:
@@ -67,25 +95,6 @@ def write(grp: h5py.Group, /, histogram: AnyHistogram) -> None:
         storage_grp.create_dataset(key, shape=npvalue.shape, data=npvalue)
 
 
-def _convert_axes(group: h5py.Group | h5py.Dataset | h5py.Datatype) -> AnyAxis:
-    """
-    Convert an HDF5 axis reference to a dictionary.
-    """
-    assert isinstance(group, h5py.Group)
-
-    axis = {k: _convert_item(k, v) for k, v in group.attrs.items()}
-    if "edges" in group:
-        edges = group["edges"]
-        assert isinstance(edges, h5py.Dataset)
-        axis["edges"] = np.asarray(edges)
-    if "categories" in group:
-        categories = group["categories"]
-        assert isinstance(categories, h5py.Dataset)
-        axis["categories"] = [_convert_item("", c) for c in categories]
-
-    return axis  # type: ignore[return-value]
-
-
 def _convert_item(name: str, item: Any, /) -> Any:
     """
     Convert an HDF5 item to a native Python type.
@@ -101,10 +110,48 @@ def _convert_item(name: str, item: Any, /) -> Any:
     return item
 
 
+def _read_metadata_writer_info(
+    output: AnyHistogram | AnyAxis, group: h5py.Group | h5py.Dataset | h5py.Datatype
+) -> None:
+    if "metadata" in group:
+        output["metadata"] = _convert_item("metadata", group["metadata"].attrs)
+    if "writer_info" in group:
+        output["writer_info"] = {
+            k: _convert_item("metadata", v.attrs)
+            for k, v in group["writer_info"].items()
+        }
+
+
+def _convert_axes(group: h5py.Group | h5py.Dataset | h5py.Datatype) -> AnyAxis:
+    """
+    Convert an HDF5 axis reference to a dictionary.
+    """
+    assert isinstance(group, h5py.Group)
+
+    axis = typing.cast(
+        AnyAxis, {k: _convert_item(k, v) for k, v in group.attrs.items()}
+    )
+    if "edges" in group:
+        edges = group["edges"]
+        assert isinstance(edges, h5py.Dataset)
+        axis["edges"] = np.asarray(edges)
+    if "categories" in group:
+        categories = group["categories"]
+        assert isinstance(categories, h5py.Dataset)
+        axis["categories"] = [_convert_item("", c) for c in categories]
+
+    _read_metadata_writer_info(axis, group)
+
+    return axis
+
+
 def read(grp: h5py.Group, /) -> Histogram:
     """
     Read a histogram from an HDF5 group.
     """
+    uhi_schema = _convert_item("", grp.attrs["uhi_schema"])
+    _check_uhi_schema_version(uhi_schema)
+
     axes_grp = grp["axes"]
     axes_ref = grp["ref_axes"]
     assert isinstance(axes_ref, h5py.Group)
@@ -118,8 +165,7 @@ def read(grp: h5py.Group, /) -> Histogram:
     for key in storage_grp:
         storage[key] = np.asarray(storage_grp[key])  # type: ignore[literal-required]
 
-    histogram_dict = AnyHistogram(axes=axes, storage=storage)
-    if "metadata" in grp:
-        histogram_dict["metadata"] = _convert_item("metadata", grp["metadata"].attrs)
+    histogram_dict = AnyHistogram(uhi_schema=uhi_schema, axes=axes, storage=storage)
+    _read_metadata_writer_info(histogram_dict, grp)
 
     return histogram_dict  # type: ignore[return-value]

--- a/src/uhi/io/json.py
+++ b/src/uhi/io/json.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 
 from . import ARRAY_KEYS
+from ._common import _convert_input
 
 __all__ = ["default", "object_hook"]
 
@@ -14,6 +15,8 @@ def __dir__() -> list[str]:
 
 
 def default(obj: Any, /) -> Any:
+    if hasattr(obj, "_to_uhi_"):
+        return _convert_input(obj)
     if isinstance(obj, np.ndarray):
         return obj.tolist()  # Convert ndarray to list
     msg = f"Object of type {type(obj)} is not JSON serializable"
@@ -24,7 +27,6 @@ def object_hook(dct: dict[str, Any], /) -> dict[str, Any]:
     """
     Decode a histogram from a dictionary.
     """
-
     for item in ARRAY_KEYS & dct.keys():
         if isinstance(dct[item], list):
             dct[item] = np.asarray(dct[item])

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -10,23 +10,11 @@
       "required": ["axes", "storage"],
       "additionalProperties": false,
       "properties": {
-        "writer_info": {
-          "type": "object",
-          "description": "Information from the library that created the histogram.",
-          "additionalProperties": false,
-          "patternProperties": {
-            ".+": {
-              "type": "object",
-              "additionalProperties": true,
-              "properties": {
-                "version": {
-                  "type": "string",
-                  "description": "Version of the library."
-                }
-              }
-            }
-          }
+        "uhi_schema": {
+          "const": 1,
+          "description": "The schema version number"
         },
+        "writer_info": { "$ref": "#/$defs/writer_info" },
         "metadata": { "$ref": "#/$defs/metadata" },
         "axes": {
           "type": "array",
@@ -75,7 +63,14 @@
       "description": "Information from the library that created the histogram.",
       "additionalProperties": false,
       "patternProperties": {
-        ".+": { "$ref": "#/$defs/supported_metadata" }
+        ".+": {
+          "type": "object",
+          "description": "Library specific information.",
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": { "$ref": "#/$defs/supported_metadata" }
+          }
+        }
       }
     },
     "ndarray": {

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -6,11 +6,14 @@ Two types of dictionaries are defined here:
    the merger of all possible types.
 2. ``Axis``, ``Storage``, and ``histogram`` are used for outputs. These have precise entries
    defined for each Literal type.
+
+There's also a Protocol, `ToUHIHistogram`, for anything that supports conversion.
 """
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict, Union
+import typing
+from typing import Literal, Protocol, TypedDict, Union
 
 from numpy.typing import ArrayLike
 
@@ -28,6 +31,7 @@ __all__ = [
     "MeanStorage",
     "RegularAxis",
     "Storage",
+    "ToUHIHistogram",
     "VariableAxis",
     "WeightedMeanStorage",
     "WeightedStorage",
@@ -52,12 +56,12 @@ class _RequiredRegularAxis(TypedDict):
 
 class RegularAxis(_RequiredRegularAxis, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class _RequiredVariableAxis(TypedDict):
     type: Literal["variable"]
-    edges: ArrayLike | str
+    edges: ArrayLike
     underflow: bool
     overflow: bool
     circular: bool
@@ -65,7 +69,7 @@ class _RequiredVariableAxis(TypedDict):
 
 class VariableAxis(_RequiredVariableAxis, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class _RequiredCategoryStrAxis(TypedDict):
@@ -76,7 +80,7 @@ class _RequiredCategoryStrAxis(TypedDict):
 
 class CategoryStrAxis(_RequiredCategoryStrAxis, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class _RequiredCategoryIntAxis(TypedDict):
@@ -87,7 +91,7 @@ class _RequiredCategoryIntAxis(TypedDict):
 
 class CategoryIntAxis(_RequiredCategoryIntAxis, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class _RequiredBooleanAxis(TypedDict):
@@ -96,38 +100,38 @@ class _RequiredBooleanAxis(TypedDict):
 
 class BooleanAxis(_RequiredBooleanAxis, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class IntStorage(TypedDict):
     type: Literal["int"]
-    values: ArrayLike | str
+    values: ArrayLike
 
 
 class DoubleStorage(TypedDict):
     type: Literal["double"]
-    values: ArrayLike | str
+    values: ArrayLike
 
 
 class WeightedStorage(TypedDict):
     type: Literal["weighted"]
-    values: ArrayLike | str
-    variances: ArrayLike | str
+    values: ArrayLike
+    variances: ArrayLike
 
 
 class MeanStorage(TypedDict):
     type: Literal["mean"]
-    counts: ArrayLike | str
-    values: ArrayLike | str
-    variances: ArrayLike | str
+    counts: ArrayLike
+    values: ArrayLike
+    variances: ArrayLike
 
 
 class WeightedMeanStorage(TypedDict):
     type: Literal["weighted_mean"]
-    sum_of_weights: ArrayLike | str
-    sum_of_weights_squared: ArrayLike | str
-    values: ArrayLike | str
-    variances: ArrayLike | str
+    sum_of_weights: ArrayLike
+    sum_of_weights_squared: ArrayLike
+    values: ArrayLike
+    variances: ArrayLike
 
 
 Storage = Union[
@@ -142,11 +146,11 @@ class _RequiredAnyStorage(TypedDict):
 
 
 class AnyStorage(_RequiredAnyStorage, total=False):
-    values: ArrayLike | str
-    variances: ArrayLike | str
-    sum_of_weights: ArrayLike | str
-    sum_of_weights_squared: ArrayLike | str
-    counts: ArrayLike | str
+    values: ArrayLike
+    variances: ArrayLike
+    sum_of_weights: ArrayLike
+    sum_of_weights_squared: ArrayLike
+    counts: ArrayLike
 
 
 class _RequiredAnyAxis(TypedDict):
@@ -155,10 +159,11 @@ class _RequiredAnyAxis(TypedDict):
 
 class AnyAxis(_RequiredAnyAxis, total=False):
     metadata: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
     lower: float
     upper: float
     bins: int
-    edges: ArrayLike | str
+    edges: ArrayLike
     categories: list[str] | list[int]
     underflow: bool
     overflow: bool
@@ -167,20 +172,27 @@ class AnyAxis(_RequiredAnyAxis, total=False):
 
 
 class _RequiredHistogram(TypedDict):
+    uhi_schema: int
     axes: list[Axis]
     storage: Storage
 
 
 class Histogram(_RequiredHistogram, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
 
 
 class _RequiredAnyHistogram(TypedDict):
+    uhi_schema: int
     axes: list[AnyAxis]
     storage: AnyStorage
 
 
 class AnyHistogram(_RequiredAnyHistogram, total=False):
     metadata: dict[str, SupportedMetadata]
-    writer_info: dict[str, SupportedMetadata]
+    writer_info: dict[str, dict[str, SupportedMetadata]]
+
+
+@typing.runtime_checkable
+class ToUHIHistogram(Protocol):
+    def _to_uhi_(self) -> Histogram: ...

--- a/tests/resources/invalid/metadata_nested.json
+++ b/tests/resources/invalid/metadata_nested.json
@@ -1,5 +1,6 @@
 {
   "one": {
+    "uhi_schema": 1,
     "metadata": { "one": { "two": 2 } },
     "axes": [],
     "storage": { "type": "int", "values": [1] }

--- a/tests/resources/invalid/missing_axis.json
+++ b/tests/resources/invalid/missing_axis.json
@@ -1,5 +1,6 @@
 {
   "one": {
+    "uhi_schema": 1,
     "storage": { "type": "int", "values": [1] }
   }
 }

--- a/tests/resources/invalid/missing_storage.json
+++ b/tests/resources/invalid/missing_storage.json
@@ -1,5 +1,6 @@
 {
   "one": {
+    "uhi_schema": 1,
     "axes": []
   }
 }

--- a/tests/resources/valid/2d.json
+++ b/tests/resources/valid/2d.json
@@ -1,5 +1,6 @@
 {
   "main": {
+    "uhi_schema": 1,
     "axes": [
       {
         "type": "variable",

--- a/tests/resources/valid/noaxes.json
+++ b/tests/resources/valid/noaxes.json
@@ -1,5 +1,6 @@
 {
   "one": {
+    "uhi_schema": 1,
     "axes": [],
     "storage": { "type": "int", "values": [1] }
   }

--- a/tests/resources/valid/reg.json
+++ b/tests/resources/valid/reg.json
@@ -1,5 +1,6 @@
 {
   "one": {
+    "uhi_schema": 1,
     "metadata": { "one": true, "two": 2, "three": "three" },
     "axes": [
       {
@@ -9,12 +10,15 @@
         "bins": 3,
         "underflow": true,
         "overflow": true,
-        "circular": false
+        "circular": false,
+        "metadata": { "simple": 1 },
+        "writer_info": { "uhi": { "bool": true } }
       }
     ],
     "storage": { "type": "int", "values": [1, 2, 3, 4, 5] }
   },
   "two": {
+    "uhi_schema": 1,
     "writer_info": {
       "uhi": {
         "version": "1.0.0",

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -35,11 +35,13 @@ def test_valid_json(filename: Path, tmp_path: Path) -> None:
         rehist = rehists[name]
 
         # Check that the JSON representation is the same
-        redata = json.dumps(hist, default=uhi.io.json.default, sort_keys=True)
-        data = json.dumps(rehist, default=uhi.io.json.default, sort_keys=True)
-        assert redata.replace(" ", "").replace("\n", "") == data.replace(
-            " ", ""
-        ).replace("\n", "")
+        data = json.dumps(hist, default=uhi.io.json.default, sort_keys=True)
+        redata = json.dumps(rehist, default=uhi.io.json.default, sort_keys=True)
+
+        redata = redata.replace(" ", "").replace("\n", "")
+        data = data.replace(" ", "").replace("\n", "")
+
+        assert redata == data
 
 
 def test_reg_load(tmp_path: Path) -> None:


### PR DESCRIPTION
This closes #156.

Also fixed `writer_info`, which was not correctly implemented in a few places (it's a dict of metadata-like, not metadata-like itself).
