### PR TITLE
feat: unserializable metadata

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -63,7 +63,9 @@ Axes with gaps are currently not supported.
 
 All axes support `metadata`, a string-valued dictionary of arbitrary data.
 Currently, strings, numbers, and booleans are supported. Other values here are
-not currently supported.
+not currently supported. Libraries are encouraged to provide a way to indicate
+unserializable metadata; our recommendation is to avoid adding any metadata
+that starts with a `@` to the metadata dictionary.
 
 The following storages are supported:
 


### PR DESCRIPTION
Close #158.

Also implemented in https://github.com/scikit-hep/boost-histogram/pull/1035.
