### PR TITLE
feat: upstreaming a bit from boost-histogram/hist

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -61,7 +61,8 @@ All axes support `metadata`, a string-valued dictionary of arbitrary data.
 Currently, strings, numbers, and booleans are supported. Other values here are
 not currently supported. Libraries are encouraged to provide a way to indicate
 unserializable metadata; our recommendation is to avoid adding any metadata
-that starts with a `@` to the metadata dictionary.
+that starts with a `@` to the metadata dictionary. Libraries should not
+include keys with `None` values, as some formats might not support null values.
 
 The following storages are supported:
 

--- a/src/uhi/io/__init__.py
+++ b/src/uhi/io/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import copy
+from typing import Any, TypeVar
+
 __all__ = ["ARRAY_KEYS", "LIST_KEYS"]
 
 ARRAY_KEYS = frozenset(
@@ -18,3 +21,29 @@ LIST_KEYS = frozenset(
         "categories",
     ]
 )
+
+T = TypeVar("T", bound="dict[str, Any]")
+
+
+def remove_writer_info(obj: T, /, *, library: str | None) -> T:
+    """
+    Removes all ``writer_info`` for a library from a histogram dict, axes dict,
+    or storage dict. Makes copies where required, and the outer dictionary is
+    always copied.
+
+    Specify a library name, or ``None`` to remove all.
+    """
+
+    obj = copy.copy(obj)
+    if library is None:
+        obj.pop("writer_info")
+    elif library in obj.get("writer_info", {}):
+        obj["writer_info"] = copy.copy(obj["writer_info"])
+        del obj["writer_info"][library]
+
+    if "axes" in obj:
+        obj["axes"] = [remove_writer_info(ax, library=library) for ax in obj["axes"]]
+    if "storage" in obj:
+        obj["storage"] = remove_writer_info(obj["storage"], library=library)
+
+    return obj

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from uhi.io import remove_writer_info
+
+
+def test_remove_writer_info() -> None:
+    d = {"uhi_schema": 1, "writer_info": {"a": {"foo": "bar"}, "b": {"FOO": "BAR"}}}
+
+    assert remove_writer_info(d, library=None) == {"uhi_schema": 1}
+    assert remove_writer_info(d, library="a") == {
+        "uhi_schema": 1,
+        "writer_info": {"b": {"FOO": "BAR"}},
+    }
+    assert remove_writer_info(d, library="b") == {
+        "uhi_schema": 1,
+        "writer_info": {"a": {"foo": "bar"}},
+    }
+    assert remove_writer_info(d, library="c") == d


### PR DESCRIPTION
This adds the removal function, and clarifies that `None` values should be trimmed. Both from boost-histogram/hist implementation work.
