### PR TITLE
refactor: use IR for intermediate representation typing helpers

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -232,10 +232,11 @@ ROOT files are not yet implemented.
 
 ## Schema
 
-A typing helper `Histogram` is provided in `uhi.typing.serialization` as a
-`TypedDict`. The schema, provided in `resources` as `histogram.schema.json`,
-also allows strings for data members, since some formats (like ZIP) put data
-into an optimized location and specify a reference to them.
+A typing helper for the intermediate representation, `HistogramIR`, is provided
+in `uhi.typing.serialization` as a `TypedDict`. The schema, provided in
+`resources` as `histogram.schema.json`, also allows strings for data members,
+since some formats (like ZIP) put data into an optimized location and specify a
+reference to them.
 
 ### Rendered schema
 

--- a/src/uhi/io/_common.py
+++ b/src/uhi/io/_common.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 __all__ = ["_check_uhi_schema_version", "_convert_input"]
 
-from ..typing.serialization import AnyHistogram, ToUHIHistogram
+from ..typing.serialization import AnyHistogramIR, ToUHIHistogram
 
 
 def _check_uhi_schema_version(uhi_schema: int, /) -> None:
@@ -15,7 +15,7 @@ def _check_uhi_schema_version(uhi_schema: int, /) -> None:
         raise TypeError(msg)
 
 
-def _convert_input(hist: AnyHistogram | ToUHIHistogram, /) -> AnyHistogram:
+def _convert_input(hist: AnyHistogramIR | ToUHIHistogram, /) -> AnyHistogramIR:
     any_hist = hist._to_uhi_() if isinstance(hist, ToUHIHistogram) else hist
     _check_uhi_schema_version(any_hist["uhi_schema"])
     return any_hist  # type: ignore[return-value]

--- a/src/uhi/io/hdf5.py
+++ b/src/uhi/io/hdf5.py
@@ -7,10 +7,10 @@ import h5py
 import numpy as np
 
 from ..typing.serialization import (
-    AnyAxis,
-    AnyHistogram,
-    AnyStorage,
-    Histogram,
+    AnyAxisIR,
+    AnyHistogramIR,
+    AnyStorageIR,
+    HistogramIR,
     SupportedMetadata,
     ToUHIHistogram,
 )
@@ -44,7 +44,7 @@ def _handle_metadata_writer_info(
                 inner_wi_grp.attrs[k] = v
 
 
-def write(grp: h5py.Group, /, histogram: AnyHistogram | ToUHIHistogram) -> None:
+def write(grp: h5py.Group, /, histogram: AnyHistogramIR | ToUHIHistogram) -> None:
     """
     Write a histogram to an HDF5 group.
     """
@@ -111,7 +111,7 @@ def _convert_item(name: str, item: Any, /) -> Any:
 
 
 def _read_metadata_writer_info(
-    output: AnyHistogram | AnyAxis, group: h5py.Group | h5py.Dataset | h5py.Datatype
+    output: AnyHistogramIR | AnyAxisIR, group: h5py.Group | h5py.Dataset | h5py.Datatype
 ) -> None:
     if "metadata" in group:
         output["metadata"] = _convert_item("metadata", group["metadata"].attrs)
@@ -122,14 +122,14 @@ def _read_metadata_writer_info(
         }
 
 
-def _convert_axes(group: h5py.Group | h5py.Dataset | h5py.Datatype) -> AnyAxis:
+def _convert_axes(group: h5py.Group | h5py.Dataset | h5py.Datatype) -> AnyAxisIR:
     """
     Convert an HDF5 axis reference to a dictionary.
     """
     assert isinstance(group, h5py.Group)
 
     axis = typing.cast(
-        AnyAxis, {k: _convert_item(k, v) for k, v in group.attrs.items()}
+        AnyAxisIR, {k: _convert_item(k, v) for k, v in group.attrs.items()}
     )
     if "edges" in group:
         edges = group["edges"]
@@ -145,7 +145,7 @@ def _convert_axes(group: h5py.Group | h5py.Dataset | h5py.Datatype) -> AnyAxis:
     return axis
 
 
-def read(grp: h5py.Group, /) -> Histogram:
+def read(grp: h5py.Group, /) -> HistogramIR:
     """
     Read a histogram from an HDF5 group.
     """
@@ -161,11 +161,11 @@ def read(grp: h5py.Group, /) -> Histogram:
 
     storage_grp = grp["storage"]
     assert isinstance(storage_grp, h5py.Group)
-    storage = AnyStorage(type=storage_grp.attrs["type"])
+    storage = AnyStorageIR(type=storage_grp.attrs["type"])
     for key in storage_grp:
         storage[key] = np.asarray(storage_grp[key])  # type: ignore[literal-required]
 
-    histogram_dict = AnyHistogram(uhi_schema=uhi_schema, axes=axes, storage=storage)
+    histogram_dict = AnyHistogramIR(uhi_schema=uhi_schema, axes=axes, storage=storage)
     _read_metadata_writer_info(histogram_dict, grp)
 
     return histogram_dict  # type: ignore[return-value]

--- a/src/uhi/io/zip.py
+++ b/src/uhi/io/zip.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import numpy as np
 
-from ..typing.serialization import AnyHistogram, ToUHIHistogram
+from ..typing.serialization import AnyHistogramIR, ToUHIHistogram
 from . import ARRAY_KEYS
 from ._common import _check_uhi_schema_version, _convert_input
 
@@ -22,7 +22,7 @@ def write(
     zip_file: zipfile.ZipFile,
     /,
     name: str,
-    histogram: AnyHistogram | ToUHIHistogram,
+    histogram: AnyHistogramIR | ToUHIHistogram,
 ) -> None:
     """
     Write a histogram to a zip file.

--- a/src/uhi/testing/indexing.py
+++ b/src/uhi/testing/indexing.py
@@ -8,7 +8,7 @@ from typing import Any
 import numpy as np
 
 import uhi.tag
-from uhi.typing.serialization import Histogram
+from uhi.typing.serialization import HistogramIR
 
 T = typing.TypeVar("T", bound=Any)
 
@@ -74,7 +74,7 @@ class Indexing1D(typing.Generic[T], Indexing):
     tag = uhi.tag
 
     @staticmethod
-    def get_uhi() -> Histogram:
+    def get_uhi() -> HistogramIR:
         return {
             "uhi_schema": 1,
             "axes": [
@@ -396,7 +396,7 @@ class Indexing2D(typing.Generic[T], Indexing):
     tag = uhi.tag
 
     @staticmethod
-    def get_uhi() -> Histogram:
+    def get_uhi() -> HistogramIR:
         x, y = np.mgrid[0:2, 0:5]
         data = np.pad(x + 2 * y, 1, mode="constant")
         return {
@@ -596,7 +596,7 @@ class Indexing3D(typing.Generic[T], Indexing):
     tag = uhi.tag
 
     @staticmethod
-    def get_uhi() -> Histogram:
+    def get_uhi() -> HistogramIR:
         x, y, z = np.mgrid[0:2, 0:5, 0:10]
         data = np.pad(x + 2 * y + 3 * z, 1, mode="constant")
         return {

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -24,23 +24,23 @@ else:
     from typing import NotRequired, Required
 
 __all__ = [
-    "AnyAxis",
-    "AnyHistogram",
-    "AnyStorage",
-    "Axis",
-    "BooleanAxis",
-    "CategoryIntAxis",
-    "CategoryStrAxis",
-    "DoubleStorage",
-    "Histogram",
-    "IntStorage",
-    "MeanStorage",
-    "RegularAxis",
-    "Storage",
+    "AnyAxisIR",
+    "AnyHistogramIR",
+    "AnyStorageIR",
+    "AxisIR",
+    "BooleanAxisIR",
+    "CategoryIntAxisIR",
+    "CategoryStrAxisIR",
+    "DoubleStorageIR",
+    "HistogramIR",
+    "IntStorageIR",
+    "MeanStorageIR",
+    "RegularAxisIR",
+    "StorageIR",
     "ToUHIHistogram",
-    "VariableAxis",
-    "WeightedMeanStorage",
-    "WeightedStorage",
+    "VariableAxisIR",
+    "WeightedMeanStorageIR",
+    "WeightedStorageIR",
 ]
 
 SupportedMetadata = Union[float, str, bool]
@@ -50,7 +50,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-class RegularAxis(TypedDict):
+class RegularAxisIR(TypedDict):
     type: Literal["regular"]
     lower: float
     upper: float
@@ -62,7 +62,7 @@ class RegularAxis(TypedDict):
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class VariableAxis(TypedDict):
+class VariableAxisIR(TypedDict):
     type: Literal["variable"]
     edges: ArrayLike
     underflow: bool
@@ -72,7 +72,7 @@ class VariableAxis(TypedDict):
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class CategoryStrAxis(TypedDict):
+class CategoryStrAxisIR(TypedDict):
     type: Literal["category_str"]
     categories: list[str]
     flow: bool
@@ -80,7 +80,7 @@ class CategoryStrAxis(TypedDict):
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class CategoryIntAxis(TypedDict):
+class CategoryIntAxisIR(TypedDict):
     type: Literal["category_int"]
     categories: list[int]
     flow: bool
@@ -88,36 +88,36 @@ class CategoryIntAxis(TypedDict):
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class BooleanAxis(TypedDict):
+class BooleanAxisIR(TypedDict):
     type: Literal["boolean"]
     metadata: NotRequired[dict[str, SupportedMetadata]]
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class IntStorage(TypedDict):
+class IntStorageIR(TypedDict):
     type: Literal["int"]
     values: ArrayLike
 
 
-class DoubleStorage(TypedDict):
+class DoubleStorageIR(TypedDict):
     type: Literal["double"]
     values: ArrayLike
 
 
-class WeightedStorage(TypedDict):
+class WeightedStorageIR(TypedDict):
     type: Literal["weighted"]
     values: ArrayLike
     variances: ArrayLike
 
 
-class MeanStorage(TypedDict):
+class MeanStorageIR(TypedDict):
     type: Literal["mean"]
     counts: ArrayLike
     values: ArrayLike
     variances: ArrayLike
 
 
-class WeightedMeanStorage(TypedDict):
+class WeightedMeanStorageIR(TypedDict):
     type: Literal["weighted_mean"]
     sum_of_weights: ArrayLike
     sum_of_weights_squared: ArrayLike
@@ -125,14 +125,20 @@ class WeightedMeanStorage(TypedDict):
     variances: ArrayLike
 
 
-Storage = Union[
-    IntStorage, DoubleStorage, WeightedStorage, MeanStorage, WeightedMeanStorage
+StorageIR = Union[
+    IntStorageIR,
+    DoubleStorageIR,
+    WeightedStorageIR,
+    MeanStorageIR,
+    WeightedMeanStorageIR,
 ]
 
-Axis = Union[RegularAxis, VariableAxis, CategoryStrAxis, CategoryIntAxis, BooleanAxis]
+AxisIR = Union[
+    RegularAxisIR, VariableAxisIR, CategoryStrAxisIR, CategoryIntAxisIR, BooleanAxisIR
+]
 
 
-class AnyStorage(TypedDict, total=False):
+class AnyStorageIR(TypedDict, total=False):
     type: Required[Literal["int", "double", "weighted", "mean", "weighted_mean"]]
     values: ArrayLike
     variances: ArrayLike
@@ -141,7 +147,7 @@ class AnyStorage(TypedDict, total=False):
     counts: ArrayLike
 
 
-class AnyAxis(TypedDict, total=False):
+class AnyAxisIR(TypedDict, total=False):
     type: Required[
         Literal["regular", "variable", "category_str", "category_int", "boolean"]
     ]
@@ -158,18 +164,18 @@ class AnyAxis(TypedDict, total=False):
     circular: bool
 
 
-class Histogram(TypedDict):
+class HistogramIR(TypedDict):
     uhi_schema: int
-    axes: list[Axis]
-    storage: Storage
+    axes: list[AxisIR]
+    storage: StorageIR
     metadata: NotRequired[dict[str, SupportedMetadata]]
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 
 
-class AnyHistogram(TypedDict):
+class AnyHistogramIR(TypedDict):
     uhi_schema: int
-    axes: list[AnyAxis]
-    storage: AnyStorage
+    axes: list[AnyAxisIR]
+    storage: AnyStorageIR
     metadata: NotRequired[dict[str, SupportedMetadata]]
     writer_info: NotRequired[dict[str, dict[str, SupportedMetadata]]]
 


### PR DESCRIPTION
The error messages from mypy were confusing, since it calls `boost_histogram.Histogram` and `uhi.typing.serialization.Histogram` both `Histogram`, so let's add IR to the typed dicts representing the intermediate representation. Helps when writing docs, too.
