### PR TITLE
chore: fix release note helper

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,5 @@
 changelog:
   exclude:
     authors:
-      - '*[bot]'
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
The `*` isn't supported, it seems. And you have to have the `[bot]` now.