### PR TITLE
fix: don't store empty metadata dict

### DIFF
--- a/src/uhi/io/_common.py
+++ b/src/uhi/io/_common.py
@@ -4,9 +4,11 @@ Common helpers for the different formats.
 
 from __future__ import annotations
 
-__all__ = ["_check_uhi_schema_version", "_convert_input"]
+import typing
 
-from ..typing.serialization import AnyHistogramIR, ToUHIHistogram
+from ..typing.serialization import AnyAxisIR, AnyHistogramIR, ToUHIHistogram
+
+__all__ = ["_check_uhi_schema_version", "_convert_input"]
 
 
 def _check_uhi_schema_version(uhi_schema: int, /) -> None:
@@ -15,7 +17,23 @@ def _check_uhi_schema_version(uhi_schema: int, /) -> None:
         raise TypeError(msg)
 
 
+def _remove_empty_metadata(hist: AnyHistogramIR, /) -> AnyHistogramIR:
+    if "metadata" in hist and not hist["metadata"]:
+        hist = typing.cast(
+            AnyHistogramIR, {k: v for k, v in hist.items() if k != "metadata"}
+        )
+    for i in range(len(hist["axes"])):
+        axis = hist["axes"][i]
+        if "metadata" in axis and not axis["metadata"]:
+            hist["axes"][i] = typing.cast(
+                AnyAxisIR, {k: v for k, v in axis.items() if k != "metadata"}
+            )
+    return hist
+
+
 def _convert_input(hist: AnyHistogramIR | ToUHIHistogram, /) -> AnyHistogramIR:
-    any_hist = hist._to_uhi_() if isinstance(hist, ToUHIHistogram) else hist
+    any_hist = typing.cast(
+        AnyHistogramIR, hist._to_uhi_() if isinstance(hist, ToUHIHistogram) else hist
+    )
     _check_uhi_schema_version(any_hist["uhi_schema"])
-    return any_hist  # type: ignore[return-value]
+    return _remove_empty_metadata(any_hist)

--- a/tests/resources/valid/mean.json
+++ b/tests/resources/valid/mean.json
@@ -10,8 +10,7 @@
         "bins": 4,
         "underflow": true,
         "overflow": true,
-        "circular": false,
-        "metadata": {}
+        "circular": false
       }
     ],
     "storage": {
@@ -37,8 +36,7 @@
         "bins": 4,
         "underflow": true,
         "overflow": true,
-        "circular": false,
-        "metadata": {}
+        "circular": false
       }
     ],
     "storage": {

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import dataclasses
+from typing import Any
+
 from uhi.io import remove_writer_info
+from uhi.io._common import _convert_input
 
 
 def test_remove_writer_info() -> None:
@@ -16,3 +20,44 @@ def test_remove_writer_info() -> None:
         "writer_info": {"a": {"foo": "bar"}},
     }
     assert remove_writer_info(d, library="c") == d
+
+
+@dataclasses.dataclass
+class _Simple:
+    value: dict[str, Any]
+
+    def _to_uhi_(self) -> dict[str, Any]:
+        return self.value
+
+
+def test_remove_empty_metadata() -> None:
+    d = {
+        "uhi_schema": 1,
+        "writer_info": {"boost-histogram": {"version": "1.6.1"}},
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": 1.0,
+                "bins": 4,
+                "underflow": True,
+                "overflow": True,
+                "circular": False,
+                "metadata": {},
+            }
+        ],
+        "storage": {
+            "type": "weighted_mean",
+            "sum_of_weights": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "sum_of_weights_squared": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "values": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "variances": [float("nan")] * 6,
+        },
+        "metadata": {},
+    }
+
+    h = _Simple(d)
+    ir = _convert_input(h)
+
+    assert "metadata" not in ir
+    assert "metadata" not in ir["axes"][0]


### PR DESCRIPTION
boost-histogram 1.6.1 always adds an empty metadata dict. Let's filter it out here if we can, since empty metadata is supposed to not add the key, not add an empty dict.
