### PR TITLE
Update boost-histogram version to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
 ]
 test-core = [
   "pytest>=6",
-  "boost-histogram>=1.4",
+  "boost-histogram>=1.6.1",
   "hist>=2.6",
   "fastjsonschema",
   "packaging",


### PR DESCRIPTION
Closes: https://github.com/scikit-hep/uhi/issues/211