### PR TITLE
fix: officially support 32-bit data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     hooks:
     - id: mypy
       files: ^(src|tests)
+      exclude: ^tests/utils
       args: []
       additional_dependencies:
         - numpy

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -68,16 +68,21 @@ The following storages are supported:
 
 * `"int"`: A collection of integers. Boost-histogram's `Int64` and `AtomicInt64`
   map to this, and sometimes `Unlimited`.
-* `"double"`: A collection of 64-bit floating point values. Boost-histogram's
+* `"double"`: A collection of floating point values. Boost-histogram's
   `Double` storage maps to this, and sometimes `Unlimited`.
-* `"weighted"`: A collection of two arrays of 64-bit floating point values,
+* `"weighted"`: A collection of two arrays of floating point values,
   `"value"` and `"variance"`. Boost-histogram's `Weight` storage maps to this.
-* `"mean"`: A collection of three arrays of 64-bit floating point values,
+* `"mean"`: A collection of three arrays of floating point values,
   "`count"`, `"value"`, and `"variance"`. Boost-histogram's `Mean` storage maps to
   this.
-* `"weighted_mean"`: A collection of four arrays of 64-bit floating point
+* `"weighted_mean"`: A collection of four arrays of floating point
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
   `"variances"`. Boost-histogram's `WeightedMean` storage maps to this.
+
+Current backends (such as zip and hdf5) allow flexibility in the size of
+integer and floating point storage. It is allowed to use a smaller floating
+point or integer storage type for such storages; the reference is 64-bit floats
+and 64-bit integers.
 
 A library can fill the optional `"writer_info"` field with a key specific to
 the library containing library specific metadata anywhere a metadata field is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
   "sphinx_github_changelog",
 ]
 test-core = [
-  "pytest>=6",
+  "pytest>=7",
   "boost-histogram>=1.6.1",
   "hist>=2.6",
   "fastjsonschema",
@@ -81,7 +81,8 @@ build.hooks.vcs.version-file = "src/uhi/_version.py"
 
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
+pythonpath = ["tests/utils"]
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
@@ -91,6 +92,7 @@ log_level = "INFO"
 
 [tool.mypy]
 files = ["src", "tests"]
+mypy_path = "tests/utils"
 python_version = "3.10"
 warn_unused_configs = true
 strict = true

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import importlib.metadata
 import json
 from pathlib import Path
+from typing import Any
 
 import packaging.version
 import pytest
+from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
 from uhi.io import to_sparse
@@ -122,3 +124,66 @@ def test_convert_hist(tmp_path: Path) -> None:
         rehist = uhi_io_hdf5.read(h5_file["histogram"])
     h2 = hist.Hist(rehist)
     assert h == h2
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param("int", id="int_storage"),
+        pytest.param("double", id="double_storage"),
+        pytest.param("weighted", id="weighted_storage"),
+        pytest.param("mean", id="mean_storage"),
+    ],
+)
+def test_convert_bh_32bit_hdf5(tmp_path: Path, storage_type: str) -> None:
+    """Test serialization of 32-bit histograms via HDF5."""
+    import boost_histogram as bh
+
+    # Create histogram with appropriate storage type
+    axis = bh.axis.Regular(5, 0, 1, __dict__={"name": "x"})
+    h: bh.Histogram[Any]
+
+    if storage_type == "int":
+        h = bh.Histogram(axis, storage=bh.storage.Int64())
+        # Fill with some data
+        for i in range(5):
+            h.fill([0.1 + i * 0.15] * 10)
+    elif storage_type == "double":
+        h = bh.Histogram(axis, storage=bh.storage.Double())
+        h.fill([0.1, 0.3, 0.5, 0.7, 0.9])
+    elif storage_type == "weighted":
+        h = bh.Histogram(axis, storage=bh.storage.Weight())
+        h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+    elif storage_type == "mean":
+        h = bh.Histogram(axis, storage=bh.storage.Mean())
+        h.fill([0.1, 0.3, 0.5], sample=[10.0, 20.0, 30.0])
+    else:
+        msg = f"Unknown storage type: {storage_type}"
+        raise ValueError(msg)
+
+    # Convert to UHI format
+    uhi_dict = h._to_uhi_()
+
+    # Convert to 32-bit
+    uhi_32bit = convert_histogram_to_32bit(uhi_dict)
+
+    # Write to HDF5
+    tmp_file = tmp_path / "test_32bit.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        uhi_io_hdf5.write(h5_file.create_group("histogram"), uhi_32bit)
+
+    # Read back from HDF5
+    with h5py.File(tmp_file, "r") as h5_file:
+        rehist_32bit = uhi_io_hdf5.read(h5_file["histogram"])
+
+    # Verify storage type and data integrity
+    assert rehist_32bit["storage"]["type"] == storage_type
+    assert "values" in rehist_32bit["storage"]
+
+    # Verify JSON representation is consistent
+    redata = json.dumps(rehist_32bit, default=uhi.io.json.default, sort_keys=True)
+    assert len(redata) > 0

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import importlib.metadata
 import json
 from pathlib import Path
+from typing import Any
 
 import packaging.version
 import pytest
+from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
 
@@ -97,3 +99,63 @@ def test_convert_hist() -> None:
     rehist = json.loads(redata, object_hook=uhi.io.json.object_hook)
     h2 = hist.Hist(rehist)
     assert h == h2
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param("int", id="int_storage"),
+        pytest.param("double", id="double_storage"),
+        pytest.param("weighted", id="weighted_storage"),
+        pytest.param("mean", id="mean_storage"),
+    ],
+)
+def test_convert_bh_32bit(storage_type: str) -> None:
+    """Test serialization of 32-bit histograms via JSON."""
+    import boost_histogram as bh
+
+    # Create histogram with appropriate storage type
+    axis = bh.axis.Regular(5, 0, 1, __dict__={"name": "x"})
+    h: bh.Histogram[Any]
+
+    if storage_type == "int":
+        h = bh.Histogram(axis, storage=bh.storage.Int64())
+        # Fill with some data
+        for i in range(5):
+            h.fill([0.1 + i * 0.15] * 10)
+    elif storage_type == "double":
+        h = bh.Histogram(axis, storage=bh.storage.Double())
+        h.fill([0.1, 0.3, 0.5, 0.7, 0.9])
+    elif storage_type == "weighted":
+        h = bh.Histogram(axis, storage=bh.storage.Weight())
+        h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+    elif storage_type == "mean":
+        h = bh.Histogram(axis, storage=bh.storage.Mean())
+        h.fill([0.1, 0.3, 0.5], sample=[10.0, 20.0, 30.0])
+    else:
+        msg = f"Unknown storage type: {storage_type}"
+        raise ValueError(msg)
+
+    # Convert to UHI format
+    uhi_dict = h._to_uhi_()
+
+    # Convert to 32-bit
+    uhi_32bit = convert_histogram_to_32bit(uhi_dict)
+
+    # Serialize via JSON
+    redata = json.dumps(uhi_32bit, default=uhi.io.json.default)
+
+    # Deserialize
+    rehist_32bit = json.loads(redata, object_hook=uhi.io.json.object_hook)
+
+    # Verify storage type and data integrity
+    assert rehist_32bit["storage"]["type"] == storage_type
+    assert "values" in rehist_32bit["storage"]
+
+    # Verify values can be serialized again without error
+    redata2 = json.dumps(rehist_32bit, default=uhi.io.json.default)
+    assert len(redata2) > 0

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -5,9 +5,11 @@ import importlib.metadata
 import json
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import packaging.version
 import pytest
+from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
 import uhi.io.zip
@@ -118,7 +120,7 @@ def test_convert_bh(tmp_path: Path) -> None:
         uhi.io.zip.write(zip_file, "histogram", h)
     with zipfile.ZipFile(tmp_file, "r") as zip_file:
         rehist = uhi.io.zip.read(zip_file, "histogram")
-    h2 = bh.Histogram[bh.storage.Double](rehist)
+    h2 = bh.Histogram[bh.storage.Weight](rehist)
 
     assert h == h2
 
@@ -145,3 +147,66 @@ def test_convert_hist(tmp_path: Path) -> None:
         rehist = uhi.io.zip.read(zip_file, "histogram")
     h2 = hist.Hist[hist.storage.Double](rehist)
     assert h == h2
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param("int", id="int_storage"),
+        pytest.param("double", id="double_storage"),
+        pytest.param("weighted", id="weighted_storage"),
+        pytest.param("mean", id="mean_storage"),
+    ],
+)
+def test_convert_bh_32bit_zip(tmp_path: Path, storage_type: str) -> None:
+    """Test serialization of 32-bit histograms via ZIP."""
+    import boost_histogram as bh
+
+    # Create histogram with appropriate storage type
+    axis = bh.axis.Regular(5, 0, 1, __dict__={"name": "x"})
+    h: bh.Histogram[Any]
+
+    if storage_type == "int":
+        h = bh.Histogram(axis, storage=bh.storage.Int64())
+        # Fill with some data
+        for i in range(5):
+            h.fill([0.1 + i * 0.15] * 10)
+    elif storage_type == "double":
+        h = bh.Histogram(axis, storage=bh.storage.Double())
+        h.fill([0.1, 0.3, 0.5, 0.7, 0.9])
+    elif storage_type == "weighted":
+        h = bh.Histogram(axis, storage=bh.storage.Weight())
+        h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+    elif storage_type == "mean":
+        h = bh.Histogram(axis, storage=bh.storage.Mean())
+        h.fill([0.1, 0.3, 0.5], sample=[10.0, 20.0, 30.0])
+    else:
+        msg = f"Unknown storage type: {storage_type}"
+        raise ValueError(msg)
+
+    # Convert to UHI format
+    uhi_dict = h._to_uhi_()
+
+    # Convert to 32-bit
+    uhi_32bit = convert_histogram_to_32bit(uhi_dict)
+
+    # Write to ZIP
+    tmp_file = tmp_path / "test_32bit.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        uhi.io.zip.write(zip_file, "histogram", uhi_32bit)
+
+    # Read back from ZIP
+    with zipfile.ZipFile(tmp_file, "r") as zip_file:
+        rehist_32bit = uhi.io.zip.read(zip_file, "histogram")
+
+    # Verify storage type and data integrity
+    assert rehist_32bit["storage"]["type"] == storage_type
+    assert "values" in rehist_32bit["storage"]
+
+    # Verify JSON representation is consistent
+    redata = json.dumps(rehist_32bit, default=uhi.io.json.default)
+    assert len(redata) > 0

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Test utilities and helpers."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -1,0 +1,151 @@
+"""Helper functions for histogram testing."""
+
+from __future__ import annotations
+
+import sys
+import typing
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+if sys.version_info < (3, 11):
+    from typing import TypeAlias
+else:
+    from typing import TypeAlias
+
+from uhi.typing.serialization import AnyHistogramIR, AnyStorageIR
+
+__all__ = ["convert_histogram_to_32bit"]
+
+# Type alias for arrays that can be converted
+ArrayLike: TypeAlias = (
+    np.ndarray | list[typing.Any] | int | np.integer | float | np.floating | None
+)
+
+
+def _convert_array_to_32bit(arr: ArrayLike) -> ArrayLike:
+    """Recursively convert numeric arrays to 32-bit precision.
+
+    Uses pattern matching to handle different array types.
+    """
+    match arr:
+        case np.ndarray():
+            if np.issubdtype(arr.dtype, np.floating):
+                return arr.astype(np.float32)
+            if np.issubdtype(arr.dtype, np.signedinteger):
+                return arr.astype(np.int32)
+            if np.issubdtype(arr.dtype, np.unsignedinteger):
+                return arr.astype(np.uint32)
+            return arr
+        case list():
+            return [_convert_array_to_32bit(item) for item in arr]
+        case int(n) if n > 2147483647 or n < -2147483648:
+            return np.int32(n)
+        case _ as other:
+            return other
+
+
+def convert_histogram_to_32bit(hist: Mapping[str, Any]) -> AnyHistogramIR:
+    """Convert a histogram dictionary to use 32-bit values where applicable.
+
+    This processes the storage arrays and converts float64 to float32 and
+    int64 to int32 (where appropriate).
+
+    Args:
+        hist: A histogram in UHI format
+
+    Returns:
+        A histogram with 32-bit precision storage arrays
+    """
+    hist_copy: AnyHistogramIR = typing.cast(AnyHistogramIR, {**hist})
+
+    if "storage" in hist_copy:
+        storage: AnyStorageIR = typing.cast(AnyStorageIR, {**hist_copy["storage"]})
+        storage_type = storage.get("type")
+
+        match storage_type:
+            case "int":
+                # Convert integer values to int32
+                if "values" in storage:
+                    storage["values"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["values"])
+                    )
+                if "index" in storage:
+                    storage["index"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["index"])
+                    )
+
+            case "double":
+                # Convert float values to float32
+                if "values" in storage:
+                    storage["values"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["values"])
+                    )
+                if "index" in storage:
+                    storage["index"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["index"])
+                    )
+
+            case "weighted":
+                # Convert float values and variances to float32
+                if "values" in storage:
+                    storage["values"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["values"])
+                    )
+                if "variances" in storage:
+                    storage["variances"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["variances"])
+                    )
+                if "index" in storage:
+                    storage["index"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["index"])
+                    )
+
+            case "mean":
+                # Convert counts, values, and variances to float32
+                if "counts" in storage:
+                    storage["counts"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["counts"])
+                    )
+                if "values" in storage:
+                    storage["values"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["values"])
+                    )
+                if "variances" in storage:
+                    storage["variances"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["variances"])
+                    )
+                if "index" in storage:
+                    storage["index"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["index"])
+                    )
+
+            case "weighted_mean":
+                # Convert all float arrays to float32
+                if "sum_of_weights" in storage:
+                    storage["sum_of_weights"] = typing.cast(
+                        np.ndarray,
+                        _convert_array_to_32bit(storage["sum_of_weights"]),
+                    )
+                if "sum_of_weights_squared" in storage:
+                    storage["sum_of_weights_squared"] = typing.cast(
+                        np.ndarray,
+                        _convert_array_to_32bit(storage["sum_of_weights_squared"]),
+                    )
+                if "values" in storage:
+                    storage["values"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["values"])
+                    )
+                if "variances" in storage:
+                    storage["variances"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["variances"])
+                    )
+                if "index" in storage:
+                    storage["index"] = typing.cast(
+                        np.ndarray, _convert_array_to_32bit(storage["index"])
+                    )
+
+        hist_copy["storage"] = storage
+
+    return hist_copy


### PR DESCRIPTION
Close #224.

Already supported, just testing and making it explicit in docs.

Bumps the pytest requirement to 7. Probably should go higher eventually (9+ has better config!).

🤖 Used claude-haiku-4.5 in vscode copilot to help.
