### PR TITLE
feat: support metadata-only histograms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,10 @@ cython_debug/
 
 # Version file
 _version.py
+
+# Editor output
+.vscode
+
+# Lockfiles
+*.lock
+pylock*.toml

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -79,6 +79,25 @@ The following storages are supported:
   values, `"sum_of_weights"`, `"sum_of_weights_squared"`, `"values"`, and
   `"variances"`. Boost-histogram's `WeightedMean` storage maps to this.
 
+All storage types support **empty (metadata-only) histograms**, where the storage
+contains only the `"type"` field and no data arrays. This is useful for creating
+histograms that contain axes and metadata but no actual bin data. Empty storages
+can be filled later or used for schema/template purposes. For example:
+
+```json
+{
+  "storage": { "type": "int" }
+}
+```
+
+Empty storages are compatible with all serialization formats and can be converted
+to/from dense or sparse forms using the standard conversion functions.
+
+```{versionadded} 1.1
+
+Empty (metadata-only) histogram support.
+```
+
 A library can fill the optional `"writer_info"` field with a key specific to
 the library containing library specific metadata anywhere a metadata field is
 allowed. There is one defined key at the Histogram level, `"version"`, which
@@ -128,6 +147,9 @@ following sparse histogram with three filled bins:
 The `0, 3` bin is filled with 5, the `1, 3` bin is filled with 6, and the
 `2, 4` bin is filled with 7. If the first axes has `"underflow"` enabled, that
 first bin is an underflow bin.
+
+Empty (metadata-only) histograms are unaffected by sparse/dense conversions; they
+remain as-is since there is no data to convert.
 
 If a histogram library doesn't support sparse histograms, you can convert a
 sparse histogram to a dense one. UHI provides helpers `uhi.io.to_sparse` and

--- a/src/uhi/io/__init__.py
+++ b/src/uhi/io/__init__.py
@@ -85,13 +85,14 @@ def _zerokey(storage_type: str, key: str) -> bool:
 def to_sparse(hist: H, /) -> H:
     """
     Convert a dense histogram to a sparse one. Leaves a sparse histogram alone.
+    Leaves empty (metadata-only) histograms alone.
     """
 
     storage = hist["storage"]
     storage_type = storage["type"]
 
-    # Ignore histograms that have 0 dimensions or are already sparse
-    if "index" in storage or not hist["axes"]:
+    # Ignore histograms that have 0 dimensions, are already sparse, or are empty
+    if "index" in storage or not hist["axes"] or len(storage) == 1:
         return hist
 
     # Get the arrays inside storage, ignoring "type"

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -228,42 +228,56 @@
     },
     "int_storage": {
       "type": "object",
-      "description": "A storage holding integer counts.",
-      "required": ["type", "values"],
+      "description": "A storage holding integer counts. Must be empty (only type), dense (type + values), or sparse (type + index + values).",
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "int" },
         "index": { "$ref": "#/$defs/sparse_array" },
         "values": { "$ref": "#/$defs/data_array" }
-      }
+      },
+      "oneOf": [
+        { "required": ["type"], "maxProperties": 1 },
+        { "required": ["type", "values"], "not": { "required": ["index"] } },
+        { "required": ["type", "index", "values"] }
+      ]
     },
     "double_storage": {
       "type": "object",
-      "description": "A storage holding floating point counts.",
-      "required": ["type", "values"],
+      "description": "A storage holding floating point counts. Must be empty (only type), dense (type + values), or sparse (type + index + values).",
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "double" },
         "index": { "$ref": "#/$defs/sparse_array" },
         "values": { "$ref": "#/$defs/data_array" }
-      }
+      },
+      "oneOf": [
+        { "required": ["type"], "maxProperties": 1 },
+        { "required": ["type", "values"], "not": { "required": ["index"] } },
+        { "required": ["type", "index", "values"] }
+      ]
     },
     "weighted_storage": {
       "type": "object",
-      "description": "A storage holding floating point counts and variances.",
-      "required": ["type", "values", "variances"],
+      "description": "A storage holding floating point counts and variances. Must be empty, dense (type + values + variances), or sparse (type + index + values + variances).",
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "weighted" },
         "index": { "$ref": "#/$defs/sparse_array" },
         "values": { "$ref": "#/$defs/data_array" },
         "variances": { "$ref": "#/$defs/data_array" }
-      }
+      },
+      "oneOf": [
+        { "required": ["type"], "maxProperties": 1 },
+        {
+          "required": ["type", "values", "variances"],
+          "not": { "required": ["index"] }
+        },
+        { "required": ["type", "index", "values", "variances"] }
+      ]
     },
     "mean_storage": {
       "type": "object",
-      "description": "A storage holding 'profile'-style floating point counts, values, and variances.",
-      "required": ["type", "counts", "values", "variances"],
+      "description": "A storage holding 'profile'-style floating point counts, values, and variances. Must be empty, dense (type + counts + values + variances), or sparse (type + index + counts + values + variances).",
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "mean" },
@@ -271,18 +285,19 @@
         "counts": { "$ref": "#/$defs/data_array" },
         "values": { "$ref": "#/$defs/data_array" },
         "variances": { "$ref": "#/$defs/data_array" }
-      }
+      },
+      "oneOf": [
+        { "required": ["type"], "maxProperties": 1 },
+        {
+          "required": ["type", "counts", "values", "variances"],
+          "not": { "required": ["index"] }
+        },
+        { "required": ["type", "index", "counts", "values", "variances"] }
+      ]
     },
     "weighted_mean_storage": {
       "type": "object",
-      "description": "A storage holding 'profile'-style floating point ∑weights, ∑weights², values, and variances.",
-      "required": [
-        "type",
-        "sum_of_weights",
-        "sum_of_weights_squared",
-        "values",
-        "variances"
-      ],
+      "description": "A storage holding 'profile'-style floating point ∑weights, ∑weights², values, and variances. Must be empty, dense (all data fields), or sparse (index + all data fields).",
       "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "const": "weighted_mean" },
@@ -291,7 +306,30 @@
         "sum_of_weights_squared": { "$ref": "#/$defs/data_array" },
         "values": { "$ref": "#/$defs/data_array" },
         "variances": { "$ref": "#/$defs/data_array" }
-      }
+      },
+      "oneOf": [
+        { "required": ["type"], "maxProperties": 1 },
+        {
+          "required": [
+            "type",
+            "sum_of_weights",
+            "sum_of_weights_squared",
+            "values",
+            "variances"
+          ],
+          "not": { "required": ["index"] }
+        },
+        {
+          "required": [
+            "type",
+            "index",
+            "sum_of_weights",
+            "sum_of_weights_squared",
+            "values",
+            "variances"
+          ]
+        }
+      ]
     }
   }
 }

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -100,37 +100,37 @@ class BooleanAxisIR(TypedDict):
 
 class IntStorageIR(TypedDict):
     type: Literal["int"]
-    values: NDArray[np.float64]
+    values: NotRequired[NDArray[np.float64]]
     index: NotRequired[NDArray[np.float64]]
 
 
 class DoubleStorageIR(TypedDict):
     type: Literal["double"]
-    values: NDArray[np.float64]
+    values: NotRequired[NDArray[np.float64]]
     index: NotRequired[NDArray[np.float64]]
 
 
 class WeightedStorageIR(TypedDict):
     type: Literal["weighted"]
-    values: NDArray[np.float64]
-    variances: NDArray[np.float64]
+    values: NotRequired[NDArray[np.float64]]
+    variances: NotRequired[NDArray[np.float64]]
     index: NotRequired[NDArray[np.float64]]
 
 
 class MeanStorageIR(TypedDict):
     type: Literal["mean"]
-    counts: NDArray[np.float64]
-    values: NDArray[np.float64]
-    variances: NDArray[np.float64]
+    counts: NotRequired[NDArray[np.float64]]
+    values: NotRequired[NDArray[np.float64]]
+    variances: NotRequired[NDArray[np.float64]]
     index: NotRequired[NDArray[np.float64]]
 
 
 class WeightedMeanStorageIR(TypedDict):
     type: Literal["weighted_mean"]
-    sum_of_weights: NDArray[np.float64]
-    sum_of_weights_squared: NDArray[np.float64]
-    values: NDArray[np.float64]
-    variances: NDArray[np.float64]
+    sum_of_weights: NotRequired[NDArray[np.float64]]
+    sum_of_weights_squared: NotRequired[NDArray[np.float64]]
+    values: NotRequired[NDArray[np.float64]]
+    variances: NotRequired[NDArray[np.float64]]
     index: NotRequired[NDArray[np.float64]]
 
 

--- a/tests/resources/valid/empty_storage.json
+++ b/tests/resources/valid/empty_storage.json
@@ -1,0 +1,76 @@
+{
+  "empty_int": {
+    "uhi_schema": 1,
+    "metadata": { "description": "metadata-only histogram with int storage" },
+    "axes": [
+      {
+        "type": "regular",
+        "lower": 0,
+        "upper": 10,
+        "bins": 5,
+        "underflow": false,
+        "overflow": false,
+        "circular": false
+      }
+    ],
+    "storage": { "type": "int" }
+  },
+  "empty_double": {
+    "uhi_schema": 1,
+    "metadata": {
+      "description": "metadata-only histogram with double storage"
+    },
+    "axes": [
+      {
+        "type": "regular",
+        "lower": 0,
+        "upper": 10,
+        "bins": 5,
+        "underflow": true,
+        "overflow": true,
+        "circular": false
+      }
+    ],
+    "storage": { "type": "double" }
+  },
+  "empty_weighted": {
+    "uhi_schema": 1,
+    "metadata": {
+      "description": "metadata-only histogram with weighted storage"
+    },
+    "axes": [
+      {
+        "type": "variable",
+        "edges": [0.0, 2.5, 5.0, 7.5, 10.0],
+        "underflow": false,
+        "overflow": false,
+        "circular": false
+      }
+    ],
+    "storage": { "type": "weighted" }
+  },
+  "empty_mean": {
+    "uhi_schema": 1,
+    "metadata": { "description": "metadata-only histogram with mean storage" },
+    "axes": [
+      {
+        "type": "category_str",
+        "categories": ["a", "b", "c"],
+        "flow": false
+      }
+    ],
+    "storage": { "type": "mean" }
+  },
+  "empty_weighted_mean": {
+    "uhi_schema": 1,
+    "metadata": {
+      "description": "metadata-only histogram with weighted_mean storage"
+    },
+    "axes": [
+      {
+        "type": "boolean"
+      }
+    ],
+    "storage": { "type": "weighted_mean" }
+  }
+}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -97,3 +97,35 @@ def test_convert_hist() -> None:
     rehist = json.loads(redata, object_hook=uhi.io.json.object_hook)
     h2 = hist.Hist(rehist)
     assert h == h2
+
+
+def test_empty_storage_roundtrip() -> None:
+    """Test that empty storages can be read and written with JSON."""
+    data = {
+        "empty_int": {
+            "uhi_schema": 1,
+            "axes": [
+                {
+                    "type": "regular",
+                    "lower": 0,
+                    "upper": 10,
+                    "bins": 5,
+                    "underflow": False,
+                    "overflow": False,
+                    "circular": False,
+                }
+            ],
+            "storage": {"type": "int"},
+        }
+    }
+
+    # Dump to JSON
+    json_str = json.dumps(data, default=uhi.io.json.default)
+
+    # Load back from JSON
+    loaded = json.loads(json_str, object_hook=uhi.io.json.object_hook)
+
+    # Verify structure is preserved
+    assert loaded == data
+    assert loaded["empty_int"]["storage"]["type"] == "int"
+    assert "values" not in loaded["empty_int"]["storage"]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
-from uhi.io import remove_writer_info
+from uhi.io import from_sparse, remove_writer_info, to_sparse
 from uhi.io._common import _convert_input
+from uhi.typing.serialization import AnyStorageIR
 
 
 def test_remove_writer_info() -> None:
@@ -61,3 +62,102 @@ def test_remove_empty_metadata() -> None:
 
     assert "metadata" not in ir
     assert "metadata" not in ir["axes"][0]
+
+
+def test_empty_storage_conversion() -> None:
+    """Test that empty storages are handled correctly during conversion."""
+    # Test each storage type with empty arrays
+    storage_types: list[tuple[str, dict[str, Any]]] = [
+        ("int", {}),
+        ("double", {}),
+        ("weighted", {}),
+        ("mean", {}),
+        ("weighted_mean", {}),
+    ]
+
+    for storage_type, arrays in storage_types:
+        d = {
+            "uhi_schema": 1,
+            "axes": [
+                {
+                    "type": "regular",
+                    "lower": 0.0,
+                    "upper": 1.0,
+                    "bins": 4,
+                    "underflow": False,
+                    "overflow": False,
+                    "circular": False,
+                }
+            ],
+            "storage": {"type": storage_type, **arrays},
+        }
+
+        h = _Simple(d)
+        ir = _convert_input(h)
+
+        storage: AnyStorageIR = ir["storage"]
+        assert storage["type"] == storage_type
+        # Verify no array fields are present
+        array_keys = {
+            "values",
+            "variances",
+            "counts",
+            "sum_of_weights",
+            "sum_of_weights_squared",
+            "index",
+        }
+        assert not any(k in storage for k in array_keys)
+
+
+def test_to_sparse_empty_storage() -> None:
+    """Test that to_sparse leaves empty storages alone."""
+    d = {
+        "uhi_schema": 1,
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": 1.0,
+                "bins": 4,
+                "underflow": False,
+                "overflow": False,
+                "circular": False,
+            }
+        ],
+        "storage": {"type": "int"},
+    }
+
+    result = to_sparse(d)
+
+    # Should return the same histogram unchanged
+    assert result == d
+    storage_result: AnyStorageIR = result["storage"]  # type: ignore[assignment]
+    assert storage_result["type"] == "int"
+    assert "values" not in storage_result
+
+
+def test_from_sparse_empty_storage() -> None:
+    """Test that from_sparse leaves empty storages alone."""
+    d = {
+        "uhi_schema": 1,
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": 1.0,
+                "bins": 4,
+                "underflow": False,
+                "overflow": False,
+                "circular": False,
+            }
+        ],
+        "storage": {"type": "double"},
+    }
+
+    result = from_sparse(d)
+
+    # Should return the same histogram unchanged
+    assert result == d
+    storage_result: AnyStorageIR = result["storage"]  # type: ignore[assignment]
+    assert storage_result["type"] == "double"
+    assert "values" not in storage_result

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -66,7 +66,9 @@ def test_all_valid(valid: Path) -> None:
     }
     shists = {k: to_sparse(v) for k, v in hists.items()}
     for h in shists.values():
-        if h["axes"]:
+        # Empty storages (metadata-only) won't get an index since there's no data
+        has_data = len(h["storage"]) > 1  # More than just "type"
+        if h["axes"] and has_data:
             assert "index" in h["storage"]
     dhists = {k: from_sparse(v) for k, v in shists.items()}
     for h in dhists.values():
@@ -77,17 +79,22 @@ def test_all_valid(valid: Path) -> None:
         assert v.keys() == dv.keys()
         assert v["axes"] == dv["axes"]
         assert v["storage"].keys() == dv["storage"].keys()
-        assert v["storage"]["values"] == pytest.approx(dv["storage"]["values"])
+        # Empty storages won't have values to compare
+        if "values" in v["storage"] and "values" in dv["storage"]:
+            assert v["storage"]["values"] == pytest.approx(dv["storage"]["values"])
         if v["storage"]["type"] == "weighted_mean":
-            v_var = v["storage"]["variances"]
-            dv_var = dv["storage"]["variances"]
-            assert np.all(np.isnan(v_var) == np.isnan(dv_var))
-            assert v_var[~np.isnan(v_var)] == pytest.approx(dv_var[~np.isnan(dv_var)])
-            assert v["storage"]["sum_of_weights"] == pytest.approx(
-                dv["storage"]["sum_of_weights"]
+            v_var = v["storage"].get("variances")
+            dv_var = dv["storage"].get("variances")
+            if v_var is not None and dv_var is not None:
+                assert np.all(np.isnan(v_var) == np.isnan(dv_var))
+                assert v_var[~np.isnan(v_var)] == pytest.approx(
+                    dv_var[~np.isnan(dv_var)]
+                )
+            assert v["storage"].get("sum_of_weights") == pytest.approx(
+                dv["storage"].get("sum_of_weights")
             )
-            assert v["storage"]["sum_of_weights_squared"] == pytest.approx(
-                dv["storage"]["sum_of_weights_squared"]
+            assert v["storage"].get("sum_of_weights_squared") == pytest.approx(
+                dv["storage"].get("sum_of_weights_squared")
             )
 
         else:


### PR DESCRIPTION
Implementation for metadata-only (no storage) histograms. I don't think we need to bump the metadata version number, as fields are not changing meaning.

🤖 Used claude-haiku-4.5 in VScode copilot.
