### PR TITLE
tests: fix installed PoI and add bh 1.7.2 tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
         - tomli
         - boost-histogram>=1.7.1
         - hist>=2.10.1
+        - dependency-groups>=1.3
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,9 @@ name: uhi
 channels:
   - conda-forge
 dependencies:
+  - boost-histogram
+  - dependency-groups
   - pip
   - pytest
-  - root
   - pytest
-  - boost-histogram
+  - root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ test-core = [
   "fastjsonschema",
   "packaging",
   "tomli; python_version<'3.11'",
+  "dependency-groups>=1.3",
 ]
 test = [
   { include-group = "test-core" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import sysconfig
 from pathlib import Path
 
 import pytest
+from dependency_groups import resolve
 from packaging.requirements import Requirement
 
 if sys.version_info < (3, 11):
@@ -46,12 +47,12 @@ def pytest_report_header() -> str:
 
     pkgs = project.get("dependencies", [])
     pkgs += [p for ps in project.get("optional-dependencies", {}).values() for p in ps]
-    pkgs += [
-        p
-        for ps in project.get("dependency-groups", {}).values()
-        for p in ps
-        if isinstance(p, str)
-    ]
+
+    # Process dependency groups, resolving {include-group = "..."} references
+    dep_groups = pyproject.get("dependency-groups", {})
+    if dep_groups:
+        pkgs += resolve(dep_groups, *dep_groups.keys())
+
     if "name" in project:
         pkgs.append(project["name"])
     interesting_packages = {Requirement(p).name for p in pkgs}

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -102,6 +102,43 @@ def test_convert_bh(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
+    packaging.version.Version("1.7.2") > BHVERSION,
+    reason="Requires boost-histogram 1.7.2+ for keep_storage=False support",
+)
+def test_convert_bh_no_storage(tmp_path: Path) -> None:
+    """Test HDF5 serialization with keep_storage=False (structure-only histograms)."""
+    import boost_histogram as bh
+    import boost_histogram.serialization
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 10, __dict__={"name": "x"}), storage=bh.storage.Weight()
+    )
+    h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+
+    # Convert to UHI format without storage values
+    uhi_dict = boost_histogram.serialization.to_uhi(h, keep_storage=False)
+
+    # Verify storage has type but no values
+    assert "storage" in uhi_dict
+    assert uhi_dict["storage"]["type"] == "weighted"
+    assert "values" not in uhi_dict["storage"]
+
+    # Write to HDF5
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        uhi_io_hdf5.write(h5_file.create_group("histogram"), uhi_dict)
+
+    # Read back from HDF5
+    with h5py.File(tmp_file, "r") as h5_file:
+        rehist = uhi_io_hdf5.read(h5_file["histogram"])
+
+    # Should be able to reconstruct a histogram with the same structure
+    h2 = bh.Histogram(rehist)
+    assert h.axes == h2.axes
+    assert isinstance(h2.storage_type(), bh.storage.Weight)
+
+
+@pytest.mark.skipif(
     packaging.version.Version("1.6.1") > BHVERSION
     or packaging.version.Version("2.9.0") > HISTVERSION,
     reason="Requires boost-histogram 1.6+ / Hist 2.9+",

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -81,6 +81,39 @@ def test_convert_bh() -> None:
 
 
 @pytest.mark.skipif(
+    packaging.version.Version("1.7.2") > BHVERSION,
+    reason="Requires boost-histogram 1.7.2+ for keep_storage=False support",
+)
+def test_convert_bh_no_storage() -> None:
+    """Test serialization with keep_storage=False (structure-only histograms)."""
+    import boost_histogram as bh
+    import boost_histogram.serialization
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 10, __dict__={"name": "x"}), storage=bh.storage.Weight()
+    )
+    h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+
+    # Convert to UHI format without storage values
+    uhi_dict = boost_histogram.serialization.to_uhi(h, keep_storage=False)
+
+    # Verify storage has type but no values
+    assert "storage" in uhi_dict
+    assert uhi_dict["storage"]["type"] == "weighted"
+    assert "values" not in uhi_dict["storage"]
+    assert "variances" not in uhi_dict["storage"]
+
+    # Should be able to serialize to JSON
+    redata = json.dumps(uhi_dict, default=uhi.io.json.default)
+    rehist = json.loads(redata, object_hook=uhi.io.json.object_hook)
+
+    # Should be able to reconstruct a histogram with the same structure
+    h2 = bh.Histogram(rehist)
+    assert h.axes == h2.axes
+    assert isinstance(h2.storage_type(), bh.storage.Weight)
+
+
+@pytest.mark.skipif(
     packaging.version.Version("1.6.1") > BHVERSION
     or packaging.version.Version("2.9.0") > HISTVERSION,
     reason="Requires boost-histogram 1.6+ / Hist 2.9+",

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -126,6 +126,48 @@ def test_convert_bh(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
+    packaging.version.Version("1.7.2") > BHVERSION,
+    reason="Requires boost-histogram 1.7.2+ for keep_storage=False support",
+)
+def test_convert_bh_no_storage(tmp_path: Path) -> None:
+    """Test ZIP serialization with keep_storage=False (structure-only histograms)."""
+    import typing
+
+    import boost_histogram as bh
+    import boost_histogram.serialization
+
+    from uhi.typing.serialization import AnyHistogramIR
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 10, __dict__={"name": "x"}), storage=bh.storage.Weight()
+    )
+    h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+
+    # Convert to UHI format without storage values
+    uhi_untyped = boost_histogram.serialization.to_uhi(h, keep_storage=False)
+    uhi_dict = typing.cast(AnyHistogramIR, uhi_untyped)
+
+    # Verify storage has type but no values
+    assert "storage" in uhi_dict
+    assert uhi_dict["storage"]["type"] == "weighted"
+    assert "values" not in uhi_dict["storage"]
+
+    # Write to ZIP
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        uhi.io.zip.write(zip_file, "histogram", uhi_dict)
+
+    # Read back from ZIP
+    with zipfile.ZipFile(tmp_file, "r") as zip_file:
+        rehist = uhi.io.zip.read(zip_file, "histogram")
+
+    # Should be able to reconstruct a histogram with the same structure
+    h2: bh.Histogram[bh.storage.Weight] = bh.Histogram(rehist)
+    assert h.axes == h2.axes
+    assert isinstance(h2.storage_type(), bh.storage.Weight)
+
+
+@pytest.mark.skipif(
     packaging.version.Version("1.6.1") > BHVERSION
     or packaging.version.Version("2.9.0") > HISTVERSION,
     reason="Requires boost-histogram 1.6+ / Hist 2.9+",


### PR DESCRIPTION
When adding tests for boost-histogram 1.7.2, I noticed the installed packages of interest were broken, so I moved to using `dependency-groups` to resolve them correctly.

:robot: Assisted-by: OpenCode:Kimi-K2.5
