### PR TITLE
fix: allow stacked values

### DIFF
--- a/src/uhi/numpy_plottable.py
+++ b/src/uhi/numpy_plottable.py
@@ -142,9 +142,18 @@ class NumPyPlottableHistogram:
 
         raw_bins: tuple[np.typing.NDArray[Any] | None, ...] = bins  # type: ignore[assignment]
 
+        if len(raw_bins) > len(hist.shape):
+            msg = f"Too many bin arrays ({len(raw_bins)}) for histogram with {hist.ndim} dimension(s)"
+            raise ValueError(msg)
+
         self.kind = kind
+        # zip over only the last len(raw_bins) dimensions, so that a 2-D
+        # "stacked" values array (e.g. multiple 1-D histograms sharing one
+        # axis) is handled naturally: the leading dimension(s) are treated as
+        # a stacking dimension and produce no axis entry.
         self.axes: Sequence[PlottableAxis] = [
-            _bin_helper(shape, b) for shape, b in zip(hist.shape, raw_bins, strict=True)
+            _bin_helper(shape, b)
+            for shape, b in zip(hist.shape[-len(raw_bins) :], raw_bins, strict=True)
         ]
 
     def __repr__(self) -> str:

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -91,6 +91,43 @@ def test_from_bh_integer() -> None:
     assert h.axes[0][2] == 3
 
 
+def test_from_numpy_stacked() -> None:
+    """Regression test for issue #233.
+
+    A tuple of (list_of_value_arrays, bin_edges) — a stacked histogram format
+    used by histoprint — was mishandled: the list was converted to a 2D array
+    but only one bin dimension was supplied, causing zip() to raise ValueError.
+    """
+    rng = np.random.default_rng(42)
+    bins = np.linspace(-5, 5, 16)  # 15 bins → 16 edges
+    values = [rng.integers(0, 300, size=15) for _ in range(3)]
+    hist = (values, bins)
+
+    h = ensure_plottable_histogram(hist)
+
+    assert h.values() == approx(np.asarray(values))
+    assert len(h.axes) == 1
+    assert len(h.axes[0]) == 15
+    assert h.axes[0][0] == approx(bins[0:2])
+    assert h.axes[0][-1] == approx(bins[-2:])
+
+
+def test_from_numpy_excess_bins_raises() -> None:
+    """If more bin arrays are provided than histogram dimensions, raise.
+
+    This exercises the new guard that prevents passing e.g. two bin arrays
+    for a 1-D values array.
+    """
+    values = np.arange(5)
+    bins1 = np.linspace(0, 5, 6)
+    bins2 = np.linspace(0, 5, 6)
+    # Provide two bin arrays for a 1-D histogram
+    hist = (values, (bins1, bins2))
+
+    with pytest.raises(ValueError, match="Too many bin arrays"):
+        ensure_plottable_histogram(hist)
+
+
 def test_from_bh_str_cat() -> None:
     bh = pytest.importorskip("boost_histogram")
     h1 = bh.Histogram(bh.axis.StrCategory(["hi", "ho"]))


### PR DESCRIPTION
Fix #233. Allow stacked histograms to work (again).

:robot: Assisted-by: Copilot:claude-sonnet-4.6
