### PR TITLE
fix: export Indexing2D from uhi.testing.indexing

### DIFF
--- a/src/uhi/testing/indexing.py
+++ b/src/uhi/testing/indexing.py
@@ -12,7 +12,7 @@ from uhi.typing.serialization import HistogramIR
 
 T = typing.TypeVar("T", bound=Any)
 
-__all__ = ["Indexing1D", "Indexing3D"]
+__all__ = ["Indexing1D", "Indexing2D", "Indexing3D"]
 
 
 if typing.TYPE_CHECKING:
@@ -427,9 +427,9 @@ class Indexing2D(typing.Generic[T], Indexing):
             },
         }
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def make_histogram() -> T:
+    def make_histogram(cls) -> T:
         pass
 
     @classmethod


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two small consistency fixes in `src/uhi/testing/indexing.py`:

- **Export `Indexing2D`**: Added `Indexing2D` to `__all__` (was `["Indexing1D", "Indexing3D"]`, now `["Indexing1D", "Indexing2D", "Indexing3D"]`). Since `__dir__` returns `__all__`, this also fixes `dir(uhi.testing.indexing)` to include the class, matching what `docs/testing.md` documents and what `tests/test_testing.py` uses.
- **Make `make_histogram` a `@classmethod`**: `Indexing2D.make_histogram` was declared with `@staticmethod` while `Indexing1D` and `Indexing3D` both use `@classmethod def make_histogram(cls) -> T`. Changed to `@classmethod @abc.abstractmethod def make_histogram(cls) -> T` for consistency.

No doc changes were needed — `docs/testing.md` already shows the correct `@classmethod` signature with `cls` for all three classes.

Part of #241

## Test plan

- [x] `uv run pytest tests/test_testing.py` — 144 passed
- [x] `uv run pytest` — 231 passed, 1 skipped (ROOT)
- [x] `prek -a --quiet` — clean
- [x] `nox -s lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)