### PR TITLE
fix: numpy_plottable adapter issues

### DIFF
--- a/src/uhi/numpy_plottable.py
+++ b/src/uhi/numpy_plottable.py
@@ -86,8 +86,17 @@ class NumPyPlottableAxis:
     def __eq__(self, other: Any) -> bool:
         """
         Needed for the protocol (should be present to be stored in a Sequence).
+
+        Returns NotImplemented when other has no .edges attribute (so Python can
+        try the reflected operation), and False when shapes differ, to avoid
+        broadcast errors inside np.allclose.
         """
-        return np.allclose(self.edges, other.edges)
+        other_edges = getattr(other, "edges", None)
+        if other_edges is None:
+            return NotImplemented
+        if self.edges.shape != other_edges.shape:
+            return False
+        return bool(np.allclose(self.edges, other_edges))
 
     def __iter__(self) -> Iterator[tuple[float, float]]:
         """
@@ -395,8 +404,12 @@ def ensure_plottable_histogram(hist: Any) -> PlottableHistogram:
             return NumPyPlottableHistogram(
                 np.asarray(hist[0]), *(None for _ in np.asarray(hist[0]).shape)
             )
-        # Standard tuple
-        return NumPyPlottableHistogram(*(np.asarray(h) for h in hist))
+        # Standard tuple — preserve None entries so _bin_helper can use the
+        # default 0..N integer-edges axis for that dimension.
+        return NumPyPlottableHistogram(
+            np.asarray(hist[0]),
+            *(None if b is None else np.asarray(b) for b in hist[1:]),
+        )
 
     if hasattr(hist, "InheritsFrom") and hist.InheritsFrom("TH1"):
         if any(

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -128,6 +128,61 @@ def test_from_numpy_excess_bins_raises() -> None:
         ensure_plottable_histogram(hist)
 
 
+def test_from_numpy_mixed_none_bins() -> None:
+    """Mixed None entries in a standard tuple should use the default integer axis.
+
+    A tuple like (vals, edges0, None) was broken: np.asarray(None) produced a
+    0-d object array, which bypassed _bin_helper's ``bins is None`` check and
+    raised ValueError.  The fix preserves None values so _bin_helper produces
+    a 0..N integer-edges axis for those dimensions.
+    """
+    values = np.zeros((3, 4))
+    edges0 = np.array([0.0, 1.0, 2.0, 3.0])
+    hist = (values, edges0, None)
+
+    h = ensure_plottable_histogram(hist)
+
+    assert h.values() == approx(values)
+    assert len(h.axes) == 2
+    # Axis 0 should use the provided edges
+    assert len(h.axes[0]) == 3
+    assert h.axes[0][0] == approx((0.0, 1.0))
+    assert h.axes[0][2] == approx((2.0, 3.0))
+    # Axis 1 should be the default integer axis (0..N)
+    assert len(h.axes[1]) == 4
+    assert h.axes[1][0] == approx((0.0, 1.0))
+    assert h.axes[1][3] == approx((3.0, 4.0))
+
+
+def test_axis_eq_non_axis_object() -> None:
+    """Comparing a NumPyPlottableAxis to a non-axis object must not raise.
+
+    __eq__ should return NotImplemented (which Python reflects to False) when
+    the other side has no .edges attribute.
+    """
+    from uhi.numpy_plottable import NumPyPlottableAxis
+
+    edges = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]])
+    axis = NumPyPlottableAxis(edges)
+
+    # Must not raise — Python reflects NotImplemented to False
+    assert (axis == "foo") is False
+    assert (axis == 42) is False
+    assert (axis == None) is False  # noqa: E711
+
+
+def test_axis_eq_different_shape() -> None:
+    """Comparing axes with different numbers of bins should return False, not raise."""
+    from uhi.numpy_plottable import NumPyPlottableAxis
+
+    edges_3 = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]])
+    edges_4 = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0], [3.0, 4.0]])
+    axis_3 = NumPyPlottableAxis(edges_3)
+    axis_4 = NumPyPlottableAxis(edges_4)
+
+    assert axis_3 != axis_4
+
+
 def test_from_bh_str_cat() -> None:
     bh = pytest.importorskip("boost_histogram")
     h1 = bh.Histogram(bh.axis.StrCategory(["hi", "ho"]))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fixes two bugs in `src/uhi/numpy_plottable.py`:

- **Mixed `None` bins rejected** (`ensure_plottable_histogram`): The "Standard tuple" branch converted every entry with `np.asarray`, turning `None` into a 0-d object array that bypassed `_bin_helper`'s `bins is None` guard, resulting in `ValueError: Bins not understood`. Fix: preserve `None` entries explicitly so `_bin_helper` falls back to the default 0..N integer-edges axis for those dimensions. A tuple such as `(vals, edges0, None)` now works as the docstring promises.
- **`NumPyPlottableAxis.__eq__` raises on non-axis operands**: Calling `axis == "foo"` raised `AttributeError` (missing `.edges`), and comparing axes with different shapes could trigger NumPy broadcast errors. Fix: return `NotImplemented` when `other` has no `.edges` attribute, and return `False` when shapes differ; only then call `bool(np.allclose(...))`.

Part of #241

## Test plan

- [x] `test_from_numpy_mixed_none_bins` — verifies that `(vals, edges0, None)` produces the right axes (real edges on axis 0, integer default on axis 1)
- [x] `test_axis_eq_non_axis_object` — verifies `axis == "foo"`, `axis == 42`, and `axis == None` all return `False` without raising
- [x] `test_axis_eq_different_shape` — verifies that comparing axes with different bin counts returns `False`
- [x] Full test suite: 234 passed, 1 skipped (ROOT not installed)
- [x] `prek -a --quiet` passes
- [x] `nox -s lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)