### PR TITLE
refactor: simplifications and modernizations

### DIFF
--- a/src/uhi/io/__init__.py
+++ b/src/uhi/io/__init__.py
@@ -63,20 +63,24 @@ def remove_writer_info(obj: T, /, *, library: str | None) -> T:
 
 
 def _compute_axis_length(axis: AxisIR) -> int:
-    if axis["type"] == "regular":
-        return axis["bins"] + axis["underflow"] + axis["overflow"]
-    if axis["type"] == "variable":
-        return len(axis["edges"]) - 1 + axis["underflow"] + axis["overflow"]
-    if axis["type"] == "category_str" or axis["type"] == "category_int":
-        return len(axis["categories"]) + axis["flow"]
-    if axis["type"] == "boolean":
-        return 2
-    assert_never(axis["type"])
+    match axis["type"]:
+        case "regular":
+            return axis["bins"] + axis["underflow"] + axis["overflow"]
+        case "variable":
+            return len(axis["edges"]) - 1 + axis["underflow"] + axis["overflow"]
+        case "category_str" | "category_int":
+            return len(axis["categories"]) + axis["flow"]
+        case "boolean":
+            return 2
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
-def _zerokey(storage_type: str, key: str) -> bool:
+def _empty_is_zero(storage_type: str, key: str) -> bool:
     """
-    Returns False if the comparison should be NaN instead of zero.
+    Returns True if empty bins should be represented as zero (the common case).
+    Returns False for weighted_mean variances, which use NaN to distinguish
+    empty bins from bins with zero variance.
     """
 
     return storage_type != "weighted_mean" or key != "variances"
@@ -101,7 +105,7 @@ def to_sparse(hist: H, /) -> H:
     # Build mask of nonzero bins across *all* present keys
     mask = np.any(
         [
-            arr != 0 if _zerokey(storage_type, k) else ~np.isnan(arr)
+            arr != 0 if _empty_is_zero(storage_type, k) else ~np.isnan(arr)
             for k, arr in arrays.items()
         ],
         axis=0,
@@ -146,13 +150,13 @@ def from_sparse(sparse: H, /) -> H:
 
     dense_storage = {"type": storage["type"]}
     for k, arr1d in storage.items():
-        arr1dnp = np.asarray(arr1d)
         if k in {"index", "type"}:
             continue
+        arr1dnp = np.asarray(arr1d)
 
         # Allocate a zeros (or nan) array of the original shape
         full = np.full(
-            shape, 0 if _zerokey(storage_type, k) else np.nan, dtype=arr1dnp.dtype
+            shape, 0 if _empty_is_zero(storage_type, k) else np.nan, dtype=arr1dnp.dtype
         )
 
         # Scatter sparse values back into dense array

--- a/src/uhi/io/__init__.py
+++ b/src/uhi/io/__init__.py
@@ -72,7 +72,7 @@ def _compute_axis_length(axis: AxisIR) -> int:
             return len(axis["categories"]) + axis["flow"]
         case "boolean":
             return 2
-        case _ as unreachable:
+        case unreachable:
             assert_never(unreachable)
 
 

--- a/src/uhi/io/hdf5.py
+++ b/src/uhi/io/hdf5.py
@@ -44,6 +44,35 @@ def _handle_metadata_writer_info(
                 inner_wi_grp.attrs[k] = v
 
 
+def _create_dataset(
+    group: h5py.Group,
+    name: str,
+    data: Any,
+    *,
+    compression: str,
+    compression_opts: int,
+    min_compress_elements: int,
+) -> None:
+    """
+    Create an HDF5 dataset, applying compression only when the element count
+    meets the minimum threshold.
+
+    ``data`` may be a NumPy array or a plain Python list (e.g. string
+    categories). The size check uses ``len()`` for lists and ``.size`` for
+    arrays so that the original type is passed through to h5py unchanged.
+    """
+    size = data.size if isinstance(data, np.ndarray) else len(data)
+    if size < min_compress_elements:
+        group.create_dataset(name, data=data)
+    else:
+        group.create_dataset(
+            name,
+            data=data,
+            compression=compression,
+            compression_opts=compression_opts,
+        )
+
+
 def write(
     grp: h5py.Group,
     /,
@@ -88,25 +117,23 @@ def write(
         for key, val2 in ax_info.items():
             ax_group.attrs[key] = val2
         if ax_edges is not None:
-            if ax_edges.size < min_compress_elements:
-                ax_group.create_dataset("edges", data=ax_edges)
-            else:
-                ax_group.create_dataset(
-                    "edges",
-                    data=ax_edges,
-                    compression=compression,
-                    compression_opts=compression_opts,
-                )
+            _create_dataset(
+                ax_group,
+                "edges",
+                ax_edges,
+                compression=compression,
+                compression_opts=compression_opts,
+                min_compress_elements=min_compress_elements,
+            )
         if ax_cats is not None:
-            if len(ax_cats) < min_compress_elements:
-                ax_group.create_dataset("categories", data=ax_cats)
-            else:
-                ax_group.create_dataset(
-                    "categories",
-                    data=ax_cats,
-                    compression=compression,
-                    compression_opts=compression_opts,
-                )
+            _create_dataset(
+                ax_group,
+                "categories",
+                ax_cats,
+                compression=compression,
+                compression_opts=compression_opts,
+                min_compress_elements=min_compress_elements,
+            )
         axes_dataset[i] = ax_group.ref
 
     # Storage
@@ -118,16 +145,14 @@ def write(
     for key, val3 in histogram["storage"].items():
         if key == "type":
             continue
-        npvalue = np.asarray(val3)
-        if npvalue.size < min_compress_elements:
-            storage_grp.create_dataset(key, data=npvalue)
-        else:
-            storage_grp.create_dataset(
-                key,
-                data=npvalue,
-                compression=compression,
-                compression_opts=compression_opts,
-            )
+        _create_dataset(
+            storage_grp,
+            key,
+            val3,
+            compression=compression,
+            compression_opts=compression_opts,
+            min_compress_elements=min_compress_elements,
+        )
 
 
 def _convert_item(name: str, item: Any, /) -> Any:

--- a/src/uhi/numpy_plottable.py
+++ b/src/uhi/numpy_plottable.py
@@ -111,12 +111,12 @@ def _bin_helper(shape: int, bins: np.typing.NDArray[Any] | None) -> NumPyPlottab
     """
     if bins is None:
         return NumPyPlottableAxis(
-            np.array([np.arange(0, shape), np.arange(1, shape + 1)]).T
+            np.column_stack([np.arange(0, shape), np.arange(1, shape + 1)])
         )
     if bins.ndim == 2:
         return NumPyPlottableAxis(bins)
     if bins.ndim == 1:
-        return NumPyPlottableAxis(np.array([bins[:-1], bins[1:]]).T)
+        return NumPyPlottableAxis(np.column_stack([bins[:-1], bins[1:]]))
     msg = "Bins not understood, should be 2d array of min/max edges or 1D array of edges or None"
     raise ValueError(msg)
 

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -27,8 +27,8 @@ def _histogram_schema() -> Callable[[dict[str, Any]], None]:
 
 def validate(data: dict[str, Any]) -> None:
     """Validate a histogram object against the schema."""
-    validate = _histogram_schema()
-    validate(data)
+    validator = _histogram_schema()
+    validator(data)
 
 
 def main(*files: str) -> None:

--- a/src/uhi/tag.py
+++ b/src/uhi/tag.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import copy
+import sys
 import typing
 from typing import Any
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 from .typing.plottable import PlottableAxis
 
@@ -11,9 +17,6 @@ __all__ = ["Locator", "Overflow", "Underflow", "at", "loc", "rebin"]
 
 def __dir__() -> list[str]:
     return __all__
-
-
-T = typing.TypeVar("T", bound="Locator")
 
 
 class Locator:
@@ -27,12 +30,12 @@ class Locator:
 
         self.offset = offset
 
-    def __add__(self: T, offset: int) -> T:
+    def __add__(self, offset: int) -> Self:
         other = copy.copy(self)
         other.offset += offset
         return other
 
-    def __sub__(self: T, offset: int) -> T:
+    def __sub__(self, offset: int) -> Self:
         other = copy.copy(self)
         other.offset -= offset
         return other
@@ -108,7 +111,12 @@ class rebin:
     divisible by n, the remainder is added to the overflow bin.
     """
 
+    __slots__ = ("factor",)
+
     def __init__(self, factor: int) -> None:
+        if not isinstance(factor, int):
+            msg = "The factor must be an integer"  # type: ignore[unreachable]
+            raise ValueError(msg)
         # Items with .factor are specially treated in boost-histogram,
         # performing a high performance rebinning
         self.factor = factor

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -155,7 +155,7 @@ AxisIR = (
 class AnyStorageIR(TypedDict, total=False):
     type: Required[Literal["int", "double", "weighted", "mean", "weighted_mean"]]
     index: NDArray[np.integer[Any]]
-    values: NDArray[np.floating[Any]]
+    values: NDArray[np.number[Any]]
     variances: NDArray[np.float64]
     sum_of_weights: NDArray[np.float64]
     sum_of_weights_squared: NDArray[np.float64]

--- a/src/uhi/typing/serialization.py
+++ b/src/uhi/typing/serialization.py
@@ -100,21 +100,21 @@ class BooleanAxisIR(TypedDict):
 
 class IntStorageIR(TypedDict):
     type: Literal["int"]
-    values: NotRequired[NDArray[np.float64]]
-    index: NotRequired[NDArray[np.float64]]
+    values: NotRequired[NDArray[np.integer[Any]]]
+    index: NotRequired[NDArray[np.integer[Any]]]
 
 
 class DoubleStorageIR(TypedDict):
     type: Literal["double"]
     values: NotRequired[NDArray[np.float64]]
-    index: NotRequired[NDArray[np.float64]]
+    index: NotRequired[NDArray[np.integer[Any]]]
 
 
 class WeightedStorageIR(TypedDict):
     type: Literal["weighted"]
     values: NotRequired[NDArray[np.float64]]
     variances: NotRequired[NDArray[np.float64]]
-    index: NotRequired[NDArray[np.float64]]
+    index: NotRequired[NDArray[np.integer[Any]]]
 
 
 class MeanStorageIR(TypedDict):
@@ -122,7 +122,7 @@ class MeanStorageIR(TypedDict):
     counts: NotRequired[NDArray[np.float64]]
     values: NotRequired[NDArray[np.float64]]
     variances: NotRequired[NDArray[np.float64]]
-    index: NotRequired[NDArray[np.float64]]
+    index: NotRequired[NDArray[np.integer[Any]]]
 
 
 class WeightedMeanStorageIR(TypedDict):
@@ -131,7 +131,7 @@ class WeightedMeanStorageIR(TypedDict):
     sum_of_weights_squared: NotRequired[NDArray[np.float64]]
     values: NotRequired[NDArray[np.float64]]
     variances: NotRequired[NDArray[np.float64]]
-    index: NotRequired[NDArray[np.float64]]
+    index: NotRequired[NDArray[np.integer[Any]]]
 
 
 StorageIR = (
@@ -154,8 +154,8 @@ AxisIR = (
 
 class AnyStorageIR(TypedDict, total=False):
     type: Required[Literal["int", "double", "weighted", "mean", "weighted_mean"]]
-    index: NDArray[np.float64]
-    values: NDArray[np.float64]
+    index: NDArray[np.integer[Any]]
+    values: NDArray[np.floating[Any]]
     variances: NDArray[np.float64]
     sum_of_weights: NDArray[np.float64]
     sum_of_weights_squared: NDArray[np.float64]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #241

## Summary

Behavior-preserving simplifications and modernizations across several files:

- **`io/hdf5.py`**: Extracted `_create_dataset` helper to deduplicate the compress-or-not logic that was written out three times (axis edges, axis categories, storage values). The helper checks `data.size` for NumPy arrays and `len()` for lists to preserve the original behavior of writing list data (e.g. string categories) directly without conversion.

- **`io/__init__.py`**: Converted `_compute_axis_length`'s if/elif chain to a `match` statement with `assert_never` in the default arm, per project guidelines encouraging pattern matching.

- **`io/__init__.py`**: Moved the `continue` guard before `np.asarray()` in `from_sparse` to avoid a pointless conversion of the `"type"` string value.

- **`io/__init__.py`**: Renamed `_zerokey` → `_empty_is_zero` with a clearer positive-framing docstring (the old docstring described when it returns `False`, which is the exceptional case).

- **`schema.py`**: Renamed the local variable `validate` to `validator` inside `validate()` to eliminate the shadowing of the enclosing function name.

- **`tag.py`**: Replaced `TypeVar("T", bound="Locator")` + `self: T` annotations in `Locator.__add__`/`__sub__` with `Self` (conditional import for Python < 3.11 using `typing_extensions`).

- **`tag.py`**: Added `__slots__ = ("factor",)` to `rebin` (the rest of the tag family already has slots). Added integer validation for `rebin.factor` using the same pattern as `Locator.__init__` validates `offset`.

- **`numpy_plottable.py`**: Replaced `np.array([a, b]).T` with `np.column_stack([a, b])` in `_bin_helper` for clarity and intent.

- **`typing/serialization.py`**: Corrected `index` fields from `NDArray[np.float64]` to `NDArray[np.integer[Any]]` across all storage IR TypedDicts and `AnyStorageIR`. Fixed `IntStorageIR.values` to `NDArray[np.integer[Any]]`. Widened `AnyStorageIR.values` to `NDArray[np.floating[Any]]` to accept float32 as well.

## Test plan

- [x] `uv run pytest` — full suite passes (231 passed, 1 skipped)
- [x] `prek -a --quiet` — all pre-commit hooks pass (including mypy and ruff)
- [x] `nox -s lint` — lint session passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)