### PR TITLE
fix: io serialization bugs

### DIFF
--- a/src/uhi/io/__init__.py
+++ b/src/uhi/io/__init__.py
@@ -49,7 +49,7 @@ def remove_writer_info(obj: T, /, *, library: str | None) -> T:
 
     obj = copy.copy(obj)
     if library is None:
-        obj.pop("writer_info")
+        obj.pop("writer_info", None)
     elif library in obj.get("writer_info", {}):
         obj["writer_info"] = copy.copy(obj["writer_info"])
         del obj["writer_info"][library]

--- a/src/uhi/io/_common.py
+++ b/src/uhi/io/_common.py
@@ -22,13 +22,15 @@ def _remove_empty_metadata(hist: AnyHistogramIR, /) -> AnyHistogramIR:
         hist = typing.cast(
             AnyHistogramIR, {k: v for k, v in hist.items() if k != "metadata"}
         )
-    for i in range(len(hist["axes"])):
-        axis = hist["axes"][i]
+    # Copy the axes list before reassigning elements so the caller's list is
+    # not mutated in place.
+    axes = list(hist["axes"])
+    for i, axis in enumerate(axes):
         if "metadata" in axis and not axis["metadata"]:
-            hist["axes"][i] = typing.cast(
+            axes[i] = typing.cast(
                 AnyAxisIR, {k: v for k, v in axis.items() if k != "metadata"}
             )
-    return hist
+    return typing.cast(AnyHistogramIR, {**hist, "axes": axes})
 
 
 def _convert_input(hist: AnyHistogramIR | ToUHIHistogram, /) -> AnyHistogramIR:

--- a/src/uhi/io/hdf5.py
+++ b/src/uhi/io/hdf5.py
@@ -192,7 +192,9 @@ def read(grp: h5py.Group, /) -> HistogramIR:
     assert isinstance(axes_ref, h5py.Group)
     assert isinstance(axes_grp, h5py.Dataset)
 
-    axes = [_convert_axes(axes_ref[unref_axis_ref]) for unref_axis_ref in axes_ref]
+    # Dereference the ordered ``axes`` dataset rather than iterating the
+    # ``ref_axes`` group, which h5py yields in alphabetical (not numeric) order.
+    axes = [_convert_axes(axes_ref[ref]) for ref in axes_grp]
 
     storage_grp = grp["storage"]
     assert isinstance(storage_grp, h5py.Group)

--- a/src/uhi/io/zip.py
+++ b/src/uhi/io/zip.py
@@ -28,16 +28,24 @@ def write(
     Write a histogram to a zip file.
     """
     histogram = _convert_input(histogram)
+    # Copy the histogram and the dicts/lists we mutate below so the caller's
+    # arrays are not replaced with path strings.
+    histogram = histogram.copy()
+
     # Write out numpy arrays to files in the zipfile
-    for storage_key in ARRAY_KEYS & histogram["storage"].keys():
+    storage = histogram["storage"].copy()
+    histogram["storage"] = storage
+    for storage_key in ARRAY_KEYS & storage.keys():
         path = f"{name}_storage_{storage_key}.npy"
         with zip_file.open(path, "w") as f:
-            np.save(f, histogram["storage"][storage_key])  # type: ignore[literal-required]
-        histogram["storage"][storage_key] = path  # type: ignore[literal-required]
+            np.save(f, storage[storage_key])  # type: ignore[literal-required]
+        storage[storage_key] = path  # type: ignore[literal-required]
 
-    for axis in histogram["axes"]:
+    axes = [axis.copy() for axis in histogram["axes"]]
+    histogram["axes"] = axes
+    for i, axis in enumerate(axes):
         for key in ARRAY_KEYS & axis.keys():
-            path = f"{name}_axis_{key}.npy"
+            path = f"{name}_axis_{i}_{key}.npy"
             with zip_file.open(path, "w") as f:
                 np.save(f, axis[key])  # type: ignore[literal-required]
             axis[key] = path  # type: ignore[literal-required]

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -79,6 +79,43 @@ def test_reg_load(tmp_path: Path, resources: Path) -> None:
     assert one["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5])
 
 
+def test_axis_order_many_axes(tmp_path: Path) -> None:
+    """Axis order must be preserved past 10 axes (issue #241).
+
+    h5py yields group members alphabetically (axis_0, axis_1, axis_10, axis_11,
+    axis_2, ...), so reading must dereference the ordered ``axes`` dataset.
+    """
+    import numpy as np
+
+    n_axes = 12
+    uppers = [float(i + 1) for i in range(n_axes)]
+    hist = {
+        "uhi_schema": 1,
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": upper,
+                "bins": 1,
+                "underflow": False,
+                "overflow": False,
+                "circular": False,
+            }
+            for upper in uppers
+        ],
+        "storage": {"type": "double", "values": np.ones((1,) * n_axes)},
+    }
+
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        uhi_io_hdf5.write(h5_file.create_group("h"), hist)
+
+    with h5py.File(tmp_file, "r") as h5_file:
+        rehist = uhi_io_hdf5.read(h5_file["h"])
+
+    assert [ax["upper"] for ax in rehist["axes"]] == pytest.approx(uppers)
+
+
 @pytest.mark.skipif(
     packaging.version.Version("1.6.1") > BHVERSION,
     reason="Requires boost-histogram 1.6+",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -22,6 +22,11 @@ def test_remove_writer_info() -> None:
     }
     assert remove_writer_info(d, library="c") == d
 
+    # A histogram without writer_info must not raise (issue #241).
+    no_wi = {"uhi_schema": 1}
+    assert remove_writer_info(no_wi, library=None) == {"uhi_schema": 1}
+    assert remove_writer_info(no_wi, library="a") == {"uhi_schema": 1}
+
 
 @dataclasses.dataclass
 class _Simple:

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-import copy
 import importlib.metadata
 import json
+import typing
 import zipfile
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import packaging.version
 import pytest
 from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
 import uhi.io.zip
-from uhi.io import to_sparse
+from uhi.io import ARRAY_KEYS, to_sparse
+from uhi.typing.serialization import AnyHistogramIR
 
 BHVERSION = packaging.version.Version(importlib.metadata.version("boost_histogram"))
 HISTVERSION = packaging.version.Version(importlib.metadata.version("hist"))
@@ -28,11 +30,20 @@ def test_valid_json(valid: Path, tmp_path: Path, sparse: bool) -> None:
     tmp_file = tmp_path / "test.zip"
     with zipfile.ZipFile(tmp_file, "w") as zip_file:
         for name, hist in hists.items():
-            uhi.io.zip.write(zip_file, name, copy.deepcopy(hist))
+            # No deepcopy: write() must not mutate the caller's histogram.
+            uhi.io.zip.write(zip_file, name, hist)
     with zipfile.ZipFile(tmp_file, "r") as zip_file:
         rehists = {name: uhi.io.zip.read(zip_file, name) for name in hists}
 
     assert hists.keys() == rehists.keys()
+
+    # write() must not replace the caller's arrays with path strings.
+    for hist in hists.values():
+        for key in ARRAY_KEYS & hist["storage"].keys():
+            assert not isinstance(hist["storage"][key], str)
+        for axis in hist["axes"]:
+            for key in ARRAY_KEYS & axis.keys():
+                assert not isinstance(axis[key], str)
 
     for name in hists:
         hist = hists[name]
@@ -103,6 +114,47 @@ def test_reg_load(tmp_path: Path, resources: Path) -> None:
 
     assert two["storage"]["type"] == "double"
     assert two["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5, 6, 7])
+
+
+def test_two_variable_axes(tmp_path: Path) -> None:
+    """Two variable axes must not collide on their zip filenames (issue #241)."""
+    edges_a = np.array([0.0, 1.0, 2.0, 3.0])
+    edges_b = np.array([0.0, 10.0, 20.0])
+
+    def axis(edges: np.ndarray) -> dict[str, Any]:
+        return {
+            "type": "variable",
+            "edges": edges,
+            "underflow": False,
+            "overflow": False,
+            "circular": False,
+        }
+
+    hist: dict[str, Any] = {
+        "uhi_schema": 1,
+        "axes": [axis(edges_a), axis(edges_b)],
+        "storage": {
+            "type": "double",
+            "values": np.zeros((len(edges_a) - 1, len(edges_b) - 1)),
+        },
+    }
+
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        uhi.io.zip.write(zip_file, "h", typing.cast(AnyHistogramIR, hist))
+        names = zip_file.namelist()
+
+    # Distinct filenames per axis (no duplicate-name UserWarning, no overwrite).
+    edge_names = [n for n in names if "_axis_" in n]
+    assert len(edge_names) == 2
+    assert len(set(edge_names)) == 2
+
+    with zipfile.ZipFile(tmp_file, "r") as zip_file:
+        rehist = uhi.io.zip.read(zip_file, "h")
+
+    # Each axis must round-trip with its own edges, not the other axis's.
+    assert rehist["axes"][0]["edges"] == pytest.approx(edges_a)
+    assert rehist["axes"][1]["edges"] == pytest.approx(edges_b)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes four verified bugs in the `uhi.io` serialization layer.

1. **zip axis filename collision** (`src/uhi/io/zip.py`) — axis arrays were all
   written as `{name}_axis_{key}.npy` with no axis index. A histogram with two
   `variable` axes wrote two colliding zip entries; on read both axes got the
   second axis's edges (silent data corruption), plus a duplicate-name
   `UserWarning`. The filename now includes the axis index
   (`{name}_axis_{i}_{key}.npy`). Previously-written files still read correctly
   since the JSON stores the path strings.

2. **`zip.write` mutated the caller's histogram** (`src/uhi/io/zip.py`,
   `src/uhi/io/_common.py`) — after `write()`, the caller's dict had `.npy`
   path strings where its numpy arrays were, in both `storage` and each axis;
   `_remove_empty_metadata` also reassigned into the shared `axes` list in
   place. Both now copy the dicts/lists before modifying them.

3. **`remove_writer_info(h, library=None)` KeyError** (`src/uhi/io/__init__.py`)
   — `obj.pop("writer_info")` raised when the histogram had no `writer_info`
   key; it now pops with a default of `None`.

4. **HDF5 `read` scrambled axis order at ≥11 dimensions** (`src/uhi/io/hdf5.py`)
   — `read()` built axes by iterating the `ref_axes` group, which h5py yields
   alphabetically (`axis_0, axis_1, axis_10, axis_11, axis_2, …`). It now
   dereferences the ordered `axes` dataset the writer creates precisely to
   preserve order.

Tests added/updated for all four cases (two-variable-axes zip round-trip with
distinct filenames and edges; zip input-mutation guard; `remove_writer_info`
without a `writer_info` key; 12-axis HDF5 round-trip preserving axis order).
Full suite passes and `prek -a` is clean.

Part of #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)