### PR TITLE
chore: secure CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,7 @@ on:
   schedule:
     - cron: "34 5 * * *"
 
-permissions:
-  actions: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,15 +19,20 @@ concurrency:
 
 jobs:
   dist:
+    name: Build distributions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: hynek/build-and-inspect-python-package@v2
+    - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   publish:
+    name: Publish to PyPI
     needs: [dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -36,20 +40,21 @@ jobs:
       name: pypi
       url: https://pypi.org/p/uhi
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write  # to publish with trusted publishing
+      attestations: write  # to attach build provenance
+      contents: read  # to attach build provenance
 
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
 
-    - uses: actions/attest-build-provenance@v4
+    - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-path: "dist/*"
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
 
   upload_nightly_wheels:
@@ -60,8 +65,9 @@ jobs:
       github.ref == 'refs/heads/main'
     needs: [dist]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
         name: Packages
         path: dist
 
-    - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+    - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-path: "dist/*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
     - main
 
+permissions: {}
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -15,6 +17,8 @@ jobs:
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read  # to check out the repository
     strategy:
       fail-fast: false
       matrix:
@@ -32,16 +36,17 @@ jobs:
           runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - uses: astral-sh/setup-uv@v8.2.0
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
     - name: Install package
       run: uv pip install --system -e.[schema] --group test
@@ -52,16 +57,19 @@ jobs:
   root:
     name: ROOT test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: conda-incubator/setup-miniconda@v4
+    - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         use-mamba: true
         environment-file: environment.yml

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,16 +16,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install tooling
         run: |

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,5 @@
+rules:
+  concurrency-limits:
+    ignore:
+      # The Copilot setup workflow only runs on demand; concurrency is not applicable.
+      - copilot-setup-steps.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       exclude: ^tests/utils
       args: []
       additional_dependencies:
-        - numpy
+        - numpy<2.5  # 3.12+ types
         - pytest
         - importlib_resources
         - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -17,15 +17,16 @@ repos:
     - id: requirements-txt-fixer
     - id: trailing-whitespace
 
+  # Held at 0.15; 0.16 adds new rules that need source changes
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.15"
+    rev: "0671d8ab202c4ac093b78433ae5baf74f3fc7246"  # frozen: v0.15.15
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
     hooks:
     - id: mypy
       files: ^(src|tests)
@@ -41,14 +42,14 @@ repos:
         - dependency-groups>=1.3
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
+    rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
     hooks:
     - id: codespell
       args: ["-L", "hist,thist,ans,nd,gaus"]
@@ -62,13 +63,13 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.3"
+    rev: "0ee178619d696787ca73d210cc191d720868c631"  # frozen: v3.9.6
     hooks:
       - id: prettier
         types_or: [json]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3  # frozen: 0.37.4
     hooks:
       - id: check-readthedocs
       - id: check-github-workflows
@@ -80,6 +81,13 @@ repos:
         files: ^tests/resources/valid/.*\.json
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.05.28
+    rev: a12c4f2e45f39cfb516be7842efbe98633eb3789  # frozen: 2026.08.05
     hooks:
       - id: validate-pyproject
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ test = [
 dev = [{ include-group = "test" }]
 
 
+[tool.uv]
+exclude-newer = "7 days"
+
+
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/uhi/_version.py"

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -41,7 +41,8 @@ def _convert_array_to_32bit(arr: ArrayLike) -> ArrayLike:
         case list():
             return [_convert_array_to_32bit(item) for item in arr]
         case int(n) if n > 2147483647 or n < -2147483648:
-            return np.int32(n)
+            # numpy's stubs type the scalar constructors as returning Any
+            return typing.cast("np.int32", np.int32(n))
         case _ as other:
             return other
 


### PR DESCRIPTION
Prompted by https://github.com/pypa/hatch/issues/2292.

:robot: _AI text below_ :robot:

- Pin every GitHub Action to a SHA with a version comment.
- Add `persist-credentials: false` to all checkout steps.
- Set `permissions: {}` at workflow level and give each job only what it needs, with comments.
- Name the anonymous CD jobs.
- Add the zizmor pre-commit hook and `.github/zizmor.yaml`, which ignores the concurrency rule for the Copilot setup workflow.
- Add a 7 day cooldown to dependabot and freeze the pre-commit hooks to SHAs.
- Add `exclude-newer = "7 days"` to `[tool.uv]`.
- Ruff stays at 0.15; 0.16 adds new rules that need source changes in a separate PR.