### PR TITLE
feat: add uhi command with validate subcommand

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -164,11 +164,17 @@ sparse histograms. Scalar histograms (with no axes) are always dense.
 
 ## CLI/API
 
-You can currently test a JSON file against the schema by running:
+You can test a JSON file against the schema with the `uhi` command (also
+`python -m uhi`):
 
 ```console
-$ python -m uhi.schema some/file.json
+$ uhi validate some/file.json
 ```
+
+```{versionadded} 1.2
+```
+
+`python -m uhi.schema some/file.json` also works.
 
 Or with code:
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -174,8 +174,6 @@ $ uhi validate some/file.json
 ```{versionadded} 1.2
 ```
 
-`python -m uhi.schema some/file.json` also works.
-
 Or with code:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ Repository = "https://github.com/Scikit-HEP/uhi"
 Documentation = "https://uhi.readthedocs.io/en/latest/"
 Changelog = "https://github.com/scikit-hep/uhi/releases"
 
+[project.scripts]
+uhi = "uhi.__main__:main"
+
 [project.optional-dependencies]
 schema = [
   "fastjsonschema",

--- a/src/uhi/__main__.py
+++ b/src/uhi/__main__.py
@@ -1,0 +1,41 @@
+"""
+Command line interface for uhi.
+
+``uhi validate`` checks JSON files against the schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+__all__ = ["main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _validate(args: argparse.Namespace) -> None:
+    from uhi.schema import main as validate_main  # noqa: PLC0415
+
+    validate_main(*args.files)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="uhi", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="validate JSON histogram files against the schema"
+    )
+    validate_parser.add_argument("files", nargs="+", help="JSON files")
+    validate_parser.set_defaults(func=_validate)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from uhi.__main__ import main
+
+
+def test_cli_validate(resources: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["validate", str(resources / "valid" / "reg.json")])
+    assert capsys.readouterr().out.startswith("OK")
+    with pytest.raises(SystemExit):
+        main(["validate", str(resources / "invalid" / "missing_axis.json")])
+    assert capsys.readouterr().out.startswith("ERROR")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `uhi` console script (also `python -m uhi`) with a `validate` subcommand that wraps the existing `uhi.schema` check. This is the base for #253, which adds an `add` subcommand.