### PR TITLE
feat: support zip, HDF5, and ROOT files in uhi validate

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -207,6 +207,13 @@ checked:
 $ uhi validate some/file.json some/other.zip some/data.h5 some/data.root
 ```
 
+For HDF5 and ROOT files, add `:path` to restrict the check to one group or
+directory inside the file, or to a single histogram:
+
+```console
+$ uhi validate some/data.h5:run1/results some/data.root:analysis/main
+```
+
 ```{versionadded} 1.2
 ```
 
@@ -224,6 +231,13 @@ uhi.schema.validate(data)
 `validate` checks a JSON file object, in either form. Use
 `uhi.schema.validate_histogram` to check a single histogram (the intermediate
 representation).
+
+`uhi.schema.load` reads any supported file into a JSON-compatible dict, with an
+optional `path` keyword for HDF5 and ROOT files:
+
+```python
+uhi.schema.validate(uhi.schema.load("data.root", path="analysis"))
+```
 
 
 ## Format specific details and helpers

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -196,11 +196,15 @@ sparse histograms. Scalar histograms (with no axes) are always dense.
 
 ## CLI/API
 
-You can test a JSON file against the schema with the `uhi` command (also
-`python -m uhi`):
+You can test a file against the schema with the `uhi` command (also
+`python -m uhi`). The format is selected by the file suffix: `.json`, `.zip`,
+`.h5`/`.hdf5`/`.hdf` (needs the `hdf5` extra), or `.root` (needs ROOT). Every
+histogram in a zip file (each `*.json` entry), HDF5 file (each group with a
+`uhi_schema` attribute), or ROOT file (each RNTuple, searched recursively) is
+checked:
 
 ```console
-$ uhi validate some/file.json
+$ uhi validate some/file.json some/other.zip some/data.h5 some/data.root
 ```
 
 ```{versionadded} 1.2
@@ -220,9 +224,6 @@ uhi.schema.validate(data)
 `validate` checks a JSON file object, in either form. Use
 `uhi.schema.validate_histogram` to check a single histogram (the intermediate
 representation).
-
-Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
-and maybe more.
 
 
 ## Format specific details and helpers

--- a/src/uhi/__main__.py
+++ b/src/uhi/__main__.py
@@ -1,7 +1,8 @@
 """
 Command line interface for uhi.
 
-``uhi validate`` checks JSON files against the schema.
+``uhi validate`` checks histogram files (JSON, zip, HDF5, or ROOT) against the
+schema.
 """
 
 from __future__ import annotations
@@ -28,9 +29,12 @@ def main(argv: Sequence[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     validate_parser = subparsers.add_parser(
-        "validate", help="validate JSON histogram files against the schema"
+        "validate",
+        help="validate histogram files (JSON, zip, HDF5, or ROOT) against the schema",
     )
-    validate_parser.add_argument("files", nargs="+", help="JSON files")
+    validate_parser.add_argument(
+        "files", nargs="+", help="histogram files (.json, .zip, .h5, .root)"
+    )
     validate_parser.set_defaults(func=_validate)
 
     args = parser.parse_args(argv)

--- a/src/uhi/__main__.py
+++ b/src/uhi/__main__.py
@@ -33,7 +33,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         help="validate histogram files (JSON, zip, HDF5, or ROOT) against the schema",
     )
     validate_parser.add_argument(
-        "files", nargs="+", help="histogram files (.json, .zip, .h5, .root)"
+        "files",
+        nargs="+",
+        help="histogram files (.json, .zip, .h5, .root); use file.h5:group or "
+        "file.root:dir to select a group or directory inside the file",
     )
     validate_parser.set_defaults(func=_validate)
 

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 import sys
 import zipfile
 from collections.abc import Callable
@@ -72,7 +73,7 @@ def _load_zip(path: Path) -> dict[str, Any]:
         return {name: uhi.io.zip.read(zip_file, name) for name in names}
 
 
-def _load_hdf5(path: Path) -> dict[str, Any]:
+def _load_hdf5(path: Path, subpath: str | None) -> dict[str, Any]:
     import h5py  # noqa: PLC0415
 
     import uhi.io.hdf5  # noqa: PLC0415
@@ -84,11 +85,14 @@ def _load_hdf5(path: Path) -> dict[str, Any]:
             hists[name] = uhi.io.hdf5.read(obj)
 
     with h5py.File(path, "r") as h5_file:
-        h5_file.visititems(visit)
+        start = h5_file[subpath] if subpath else h5_file
+        if "uhi_schema" in start.attrs:
+            return dict(uhi.io.hdf5.read(start))
+        start.visititems(visit)
     return hists
 
 
-def _load_root(path: Path) -> dict[str, Any]:
+def _load_root(path: Path, subpath: str | None) -> dict[str, Any]:
     import ROOT  # noqa: PLC0415
 
     import uhi.io.root  # noqa: PLC0415
@@ -109,27 +113,58 @@ def _load_root(path: Path) -> dict[str, Any]:
         msg = f"Could not open {path} as a ROOT file"
         raise OSError(msg)
     with root_file:
-        visit(root_file, "")
-    return hists
+        if not subpath:
+            visit(root_file, "")
+            return hists
+        parent, _, name = subpath.rstrip("/").rpartition("/")
+        directory = root_file.Get(parent) if parent else root_file
+        key = directory.GetKey(name) if directory else None
+        if not key:
+            msg = f"{subpath!r} not found in {path}"
+            raise KeyError(msg)
+        if key.GetClassName() in {"TDirectory", "TDirectoryFile"}:
+            visit(directory.Get(name), "")
+            return hists
+        # A single RNTuple
+        return uhi.io.root.read(directory, name)
 
 
-def load(file: str | Path, /) -> dict[str, Any]:
+_SPEC_RE = re.compile(r"^(.+?\.(?:json|zip|h5|hdf5|hdf|root)):(.+)$", re.IGNORECASE)
+
+
+def _split_spec(spec: str) -> tuple[str, str | None]:
+    """Split ``file.root:dir/name`` into ``("file.root", "dir/name")``."""
+    if match := _SPEC_RE.match(spec):
+        return match[1], match[2]
+    return spec, None
+
+
+def load(file: str | Path, /, *, path: str | None = None) -> dict[str, Any]:
     """
     Load all histograms from a file as a ``{name: histogram}`` dict with
     JSON-compatible values. The format is selected by suffix: ``.json``,
     ``.zip``, ``.h5``/``.hdf5``/``.hdf``, or ``.root``.
+
+    For HDF5 and ROOT files, ``path`` restricts the search to a group or
+    directory inside the file. If it names a single histogram, that histogram
+    is returned instead of a dict.
     """
-    path = Path(file)
-    match path.suffix.lower():
-        case ".json":
-            with path.open(encoding="utf-8") as f:
-                data: dict[str, Any] = json.load(f)
-        case ".zip":
-            data = _load_zip(path)
+    filepath = Path(file)
+    match filepath.suffix.lower():
         case ".h5" | ".hdf5" | ".hdf":
-            data = _load_hdf5(path)
+            data = _load_hdf5(filepath, path)
         case ".root":
-            data = _load_root(path)
+            data = _load_root(filepath, path)
+        case _ if path:
+            msg = (
+                f"An in-file path ({path!r}) is only supported for HDF5 and ROOT files"
+            )
+            raise ValueError(msg)
+        case ".json":
+            with filepath.open(encoding="utf-8") as f:
+                data = json.load(f)
+        case ".zip":
+            data = _load_zip(filepath)
         case suffix:
             msg = f"Unknown file format {suffix!r}, expected .json, .zip, .h5, or .root"
             raise ValueError(msg)
@@ -143,8 +178,9 @@ def main(*files: str) -> None:
     retval = 0
 
     for file in files:
+        filename, path = _split_spec(file)
         try:
-            validate(load(file))
+            validate(load(filename, path=path))
         except fastjsonschema.JsonSchemaValueException as e:
             print(f"ERROR {file}: {e.message}")  # noqa: T201
             retval = 1

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import json
 import sys
+import zipfile
 from collections.abc import Callable
 from importlib import resources
 from pathlib import Path
@@ -12,7 +13,13 @@ _resources = resources.files("uhi") / "resources"
 histogram_file = _resources / "histogram.schema.json"
 histograms_file = _resources / "histograms.schema.json"
 
-__all__ = ["histogram_file", "histograms_file", "validate", "validate_histogram"]
+__all__ = [
+    "histogram_file",
+    "histograms_file",
+    "load",
+    "validate",
+    "validate_histogram",
+]
 
 
 def __dir__() -> list[str]:
@@ -49,6 +56,86 @@ def validate_histogram(data: dict[str, Any]) -> None:
     _compile("histogram.schema.json")(data)
 
 
+def _to_json_compatible(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert NumPy arrays and scalars so the schema validator can check them."""
+    from uhi.io.json import default  # noqa: PLC0415
+
+    result: dict[str, Any] = json.loads(json.dumps(data, default=default))
+    return result
+
+
+def _load_zip(path: Path) -> dict[str, Any]:
+    import uhi.io.zip  # noqa: PLC0415
+
+    with zipfile.ZipFile(path) as zip_file:
+        names = [n[:-5] for n in zip_file.namelist() if n.endswith(".json")]
+        return {name: uhi.io.zip.read(zip_file, name) for name in names}
+
+
+def _load_hdf5(path: Path) -> dict[str, Any]:
+    import h5py  # noqa: PLC0415
+
+    import uhi.io.hdf5  # noqa: PLC0415
+
+    hists: dict[str, Any] = {}
+
+    def visit(name: str, obj: Any) -> None:
+        if isinstance(obj, h5py.Group) and "uhi_schema" in obj.attrs:
+            hists[name] = uhi.io.hdf5.read(obj)
+
+    with h5py.File(path, "r") as h5_file:
+        h5_file.visititems(visit)
+    return hists
+
+
+def _load_root(path: Path) -> dict[str, Any]:
+    import ROOT  # noqa: PLC0415
+
+    import uhi.io.root  # noqa: PLC0415
+
+    hists: dict[str, Any] = {}
+
+    def visit(directory: Any, prefix: str) -> None:
+        for key in directory.GetListOfKeys():
+            name = key.GetName()
+            match key.GetClassName():
+                case "ROOT::RNTuple" | "ROOT::Experimental::RNTuple":
+                    hists[f"{prefix}{name}"] = uhi.io.root.read(directory, name)
+                case "TDirectory" | "TDirectoryFile":
+                    visit(directory.Get(name), f"{prefix}{name}/")
+
+    root_file = ROOT.TFile.Open(str(path))
+    if not root_file:
+        msg = f"Could not open {path} as a ROOT file"
+        raise OSError(msg)
+    with root_file:
+        visit(root_file, "")
+    return hists
+
+
+def load(file: str | Path, /) -> dict[str, Any]:
+    """
+    Load all histograms from a file as a ``{name: histogram}`` dict with
+    JSON-compatible values. The format is selected by suffix: ``.json``,
+    ``.zip``, ``.h5``/``.hdf5``/``.hdf``, or ``.root``.
+    """
+    path = Path(file)
+    match path.suffix.lower():
+        case ".json":
+            with path.open(encoding="utf-8") as f:
+                data: dict[str, Any] = json.load(f)
+        case ".zip":
+            data = _load_zip(path)
+        case ".h5" | ".hdf5" | ".hdf":
+            data = _load_hdf5(path)
+        case ".root":
+            data = _load_root(path)
+        case suffix:
+            msg = f"Unknown file format {suffix!r}, expected .json, .zip, .h5, or .root"
+            raise ValueError(msg)
+    return _to_json_compatible(data)
+
+
 def main(*files: str) -> None:
     """Validate histogram files."""
     import fastjsonschema  # noqa: PLC0415
@@ -56,12 +143,13 @@ def main(*files: str) -> None:
     retval = 0
 
     for file in files:
-        with Path(file).open(encoding="utf-8") as f:
-            data = json.load(f)
         try:
-            validate(data)
+            validate(load(file))
         except fastjsonschema.JsonSchemaValueException as e:
             print(f"ERROR {file}: {e.message}")  # noqa: T201
+            retval = 1
+        except (OSError, ValueError, TypeError, KeyError, ImportError) as e:
+            print(f"ERROR {file}: {e}")  # noqa: T201
             retval = 1
         else:
             print(f"OK {file}")  # noqa: T201

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 
 import uhi.io.json
 import uhi.io.zip
+import uhi.schema
 from uhi.__main__ import main
 
 
@@ -106,4 +107,64 @@ def test_cli_validate_hdf5_invalid(
 
     with pytest.raises(SystemExit):
         main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("data.json", ("data.json", None)),
+        ("data.root:sub/dir", ("data.root", "sub/dir")),
+        ("some/dir/data.h5:grp", ("some/dir/data.h5", "grp")),
+        ("C:\\dir\\data.ROOT:grp", ("C:\\dir\\data.ROOT", "grp")),
+        ("C:\\dir\\data.root", ("C:\\dir\\data.root", None)),
+    ],
+)
+def test_split_spec(spec: str, expected: tuple[str, str | None]) -> None:
+    assert uhi.schema._split_spec(spec) == expected
+
+
+def test_cli_validate_path_unsupported(
+    resources: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit):
+        main(["validate", f"{resources / 'valid' / 'reg.json'}:main"])
+    assert "only supported for HDF5 and ROOT" in capsys.readouterr().out
+
+
+def test_cli_validate_hdf5_path(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        good = h5_file.create_group("good")
+        for name, hist in hists.items():
+            uhi_io_hdf5.write(good.create_group(name), hist)
+        bad = h5_file.create_group("bad")
+        for name, hist in hists.items():
+            grp = bad.create_group(name)
+            uhi_io_hdf5.write(grp, hist)
+            grp["storage"].attrs["type"] = "not_a_storage"
+
+    assert set(uhi.schema.load(tmp_file, path="good")) == set(hists)
+    assert set(uhi.schema.load(tmp_file, path="/good/")) == set(hists)
+    single = uhi.schema.load(tmp_file, path="good/one")
+    assert single["uhi_schema"] == 1
+
+    main(["validate", f"{tmp_file}:good", f"{tmp_file}:good/one"])
+    assert capsys.readouterr().out.count("OK") == 2
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:bad"])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:missing"])
     assert capsys.readouterr().out.startswith("ERROR")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+import zipfile
 from pathlib import Path
 
 import pytest
 
+import uhi.io.json
+import uhi.io.zip
 from uhi.__main__ import main
 
 
@@ -14,4 +18,92 @@ def test_cli_validate(resources: Path, capsys: pytest.CaptureFixture[str]) -> No
     assert capsys.readouterr().out.startswith("OK")
     with pytest.raises(SystemExit):
         main(["validate", str(resources / "invalid" / "missing_axis.json")])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+def test_cli_validate_unknown_format(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "hist.txt"
+    bad.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        main(["validate", str(bad)])
+    assert "Unknown file format '.txt'" in capsys.readouterr().out
+
+
+def test_cli_validate_zip(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        for name, hist in hists.items():
+            uhi.io.zip.write(zip_file, name, hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_zip_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        for name, hist in hists.items():
+            uhi.io.zip.write(zip_file, name, hist)
+        # A bare JSON entry without the required keys
+        zip_file.writestr("broken.json", json.dumps({"uhi_schema": 1, "axes": []}))
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
+    out = capsys.readouterr().out
+    assert out.startswith("ERROR")
+    assert "storage" in out
+
+
+def test_cli_validate_hdf5(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        # Nest one level to check that groups are discovered recursively
+        grp = h5_file.create_group("nested")
+        for name, hist in hists.items():
+            uhi_io_hdf5.write(grp.create_group(name), hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_hdf5_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        for name, hist in hists.items():
+            grp = h5_file.create_group(name)
+            uhi_io_hdf5.write(grp, hist)
+            grp["storage"].attrs["type"] = "not_a_storage"
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
     assert capsys.readouterr().out.startswith("ERROR")

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,6 +12,7 @@ from helpers import convert_histogram_to_32bit
 from pytest import approx
 
 import uhi.io.json
+import uhi.schema
 from uhi.io import ARRAY_KEYS, to_sparse
 from uhi.numpy_plottable import ensure_plottable_histogram
 
@@ -419,4 +420,40 @@ def test_cli_validate_root_invalid(
 
     with pytest.raises(SystemExit):
         main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+def test_cli_validate_root_path(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        good = root_file.mkdir("good")
+        bad = root_file.mkdir("bad")
+        for name, hist in hists.items():
+            uhi_io_root.write(good, name, hist)
+            broken = {**hist, "storage": {**hist["storage"], "type": "not_a_storage"}}
+            uhi_io_root.write(bad, name, broken)
+
+    assert set(uhi.schema.load(tmp_file, path="good")) == set(hists)
+    assert set(uhi.schema.load(tmp_file, path="good/")) == set(hists)
+    single = uhi.schema.load(tmp_file, path="good/one")
+    assert single["uhi_schema"] == 1
+
+    main(["validate", f"{tmp_file}:good", f"{tmp_file}:good/one"])
+    assert capsys.readouterr().out.count("OK") == 2
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:bad"])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:missing"])
     assert capsys.readouterr().out.startswith("ERROR")

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -375,3 +375,48 @@ def test_convert_bh_32bit_root(tmp_path: Path, storage_type: str) -> None:
     assert rehist_32bit["storage"]["values"] == pytest.approx(
         uhi_32bit["storage"]["values"]
     )
+
+
+# CLI
+
+
+def test_cli_validate_root(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        # Nest one level to check that directories are searched recursively
+        directory = root_file.mkdir("nested")
+        for name, hist in hists.items():
+            uhi_io_root.write(directory, name, hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_root_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        for name, hist in hists.items():
+            hist = dict(hist)  # noqa: PLW2901
+            hist["storage"] = {**hist["storage"], "type": "not_a_storage"}
+            uhi_io_root.write(root_file, name, hist)
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("ERROR")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`uhi validate` now accepts `.json`, `.zip`, `.h5`/`.hdf5`/`.hdf`, and `.root` files, selected by suffix.

- New `uhi.schema.load(file)` reads any supported format into a `{name: histogram}` dict with JSON-compatible values. Each `*.json` entry in a zip is one histogram. HDF5 files are walked recursively, and each group with a `uhi_schema` attribute is one histogram keyed by its path. ROOT files are walked recursively too, and each RNTuple is one histogram keyed by its path.
- Load errors (unknown suffix, missing h5py or ROOT, unsupported schema version) print an `ERROR` line and set a non-zero exit code instead of raising.
- Docs updated; the "eventually zip and HDF5" note is removed.

The ROOT tests run in `nox -s root_tests`.