### PR TITLE
feat(io): add ROOT serialization backend

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -13,9 +13,9 @@ well.
 The following formats are being targeted:
 
 ```
-┌──────────────┐ ┌────────┐ ┌────────────┐
-│  ROOT (todo) │ │  HDF5  │ │  ZIP/JSON  │
-└──────────────┘ └────────┘ └────────────┘
+┌────────┐ ┌────────┐ ┌────────────┐
+│  ROOT  │ │  HDF5  │ │  ZIP/JSON  │
+└────────┘ └────────┘ └────────────┘
 ```
 
 Other formats can be used as well, assuming they support out-of-band data and
@@ -297,7 +297,36 @@ currently (as of 3.14rc2) doesn't provide 3.14 wheels either.
 
 ### ROOT
 
-ROOT files are not yet implemented.
+The ROOT format stores each histogram as a single-entry
+[RNTuple](https://root.cern/doc/master/classROOT_1_1RNTuple.html). You need
+[ROOT](https://root.cern) installed to use this format (`conda install -c
+conda-forge root`). The RNTuple has a `"uhi"` string
+field holding the IR as a string and arrays are replaced
+by the name of the field holding them. Storage arrays are stored flattened in
+`std::vector` fields named after their key (`"values"`, `"variances"`, ...). The shape of these arrays is recovered from the axes when reading.
+The `edges` of a variable axis is stored the same way in
+a field named `"axis_{i}_edges"`, where `i` is the axis index.
+
+We provide `uhi.io.root.read` and `uhi.io.root.write`, which work with an open
+`TFile` or `RFile`.
+
+```python
+import ROOT
+import uhi.io.root
+
+with ROOT.TFile.Open("myfile.root", "RECREATE") as root_file:
+    uhi.io.root.write(root_file, "histogram", h)
+
+with ROOT.TFile.Open("myfile.root") as root_file:
+    h2 = uhi.io.root.read(root_file, "histogram")
+```
+
+Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
+representation, and `h2` is an intermediate representation;
+you can pass it to `ROOT.TH1*` or `boost_histogram.Histogram` or `hist.Hist`.
+
+```{versionadded} 1.2
+```
 
 ## Schema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ schema = [
 hdf5 = [
   "h5py",
 ]
+root = [
+  "ROOT",
+]
 
 [dependency-groups]
 docs = [
@@ -109,7 +112,7 @@ warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
-module = ["fastjsonschema", "h5py"]
+module = ["fastjsonschema", "h5py", "ROOT"]
 ignore_missing_imports = true
 
 

--- a/src/uhi/io/root.py
+++ b/src/uhi/io/root.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import json
 from typing import Any
 
@@ -78,13 +77,6 @@ def write(
         writer.Fill(entry)
 
 
-def _object_hook(dct: dict[str, Any], /, *, entry: Any) -> dict[str, Any]:
-    for item in ARRAY_KEYS & dct.keys():
-        if isinstance(dct[item], str):
-            dct[item] = np.array(entry[dct[item]])
-    return dct
-
-
 def read(directory: ROOT.TDirectory, /, name: str) -> dict[str, Any]:
     """
     Read a histogram from a ROOT directory.
@@ -92,8 +84,13 @@ def read(directory: ROOT.TDirectory, /, name: str) -> dict[str, Any]:
     with ROOT.RNTupleReader.Open(directory.Get(name)) as reader:
         entry = reader.CreateEntry()
         reader.LoadEntry(0, entry)
-        object_hook = functools.partial(_object_hook, entry=entry)
-        output: dict[str, Any] = json.loads(str(entry["uhi"]), object_hook=object_hook)
+        output: dict[str, Any] = json.loads(str(entry["uhi"]))
+        # Only storage and axes contain array references; metadata and writer
+        # info may use the same keys for arbitrary strings.
+        for obj in [output["storage"], *output["axes"]]:
+            for key in ARRAY_KEYS & obj.keys():
+                if isinstance(obj[key], str):
+                    obj[key] = np.array(entry[obj[key]])
     _check_uhi_schema_version(output["uhi_schema"])
 
     # Arrays are stored flattened; the shape is recovered from the axes

--- a/src/uhi/io/root.py
+++ b/src/uhi/io/root.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import functools
+import json
+from typing import Any
+
+import numpy as np
+import ROOT
+
+from ..typing.serialization import AnyHistogramIR, ToUHIHistogram
+from . import ARRAY_KEYS, _compute_axis_length
+from ._common import _check_uhi_schema_version, _convert_input
+
+__all__ = ["read", "write"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+_FIELD_TYPES = {
+    "float64": "double",
+    "float32": "float",
+    "int64": "std::int64_t",
+    "int32": "std::int32_t",
+    "uint64": "std::uint64_t",
+    "uint32": "std::uint32_t",
+}
+
+
+def write(
+    directory: ROOT.TDirectory,
+    /,
+    name: str,
+    histogram: AnyHistogramIR | ToUHIHistogram,
+) -> None:
+    """
+    Write a histogram to a ROOT directory as a single-entry RNTuple. The
+    histogram JSON is stored in the ``uhi`` field; each array is stored
+    flattened in a vector field of the same name.
+    """
+    histogram = _convert_input(histogram)
+    # Copy the histogram and the dicts/lists we mutate below so the caller's
+    # arrays are not replaced with field names.
+    histogram = histogram.copy()
+
+    arrays: dict[str, np.ndarray[Any, Any]] = {}
+    storage = histogram["storage"].copy()
+    histogram["storage"] = storage
+    for storage_key in ARRAY_KEYS & storage.keys():
+        arrays[storage_key] = np.asarray(storage[storage_key])  # type: ignore[literal-required]
+        storage[storage_key] = storage_key  # type: ignore[literal-required]
+
+    axes = [axis.copy() for axis in histogram["axes"]]
+    histogram["axes"] = axes
+    for i, axis in enumerate(axes):
+        for key in ARRAY_KEYS & axis.keys():
+            field = f"axis_{i}_{key}"
+            arrays[field] = np.asarray(axis[key])  # type: ignore[literal-required]
+            axis[key] = field  # type: ignore[literal-required]
+
+    model = ROOT.RNTupleModel.Create()
+    model.MakeField["std::string"]("uhi")
+    vectors = {}
+    for field, array in arrays.items():
+        ctype = _FIELD_TYPES.get(array.dtype.name)
+        if ctype is None:
+            msg = f"Unsupported array dtype {array.dtype} for {field}"
+            raise TypeError(msg)
+        model.MakeField[f"std::vector<{ctype}>"](field)
+        vectors[field] = ROOT.std.vector[ctype](array.ravel())
+
+    with ROOT.RNTupleWriter.Append(model, name, directory) as writer:
+        entry = writer.CreateEntry()
+        entry["uhi"] = json.dumps(histogram)
+        for field, vector in vectors.items():
+            entry[field] = ROOT.std.move(vector)
+        writer.Fill(entry)
+
+
+def _object_hook(dct: dict[str, Any], /, *, entry: Any) -> dict[str, Any]:
+    for item in ARRAY_KEYS & dct.keys():
+        if isinstance(dct[item], str):
+            dct[item] = np.array(entry[dct[item]])
+    return dct
+
+
+def read(directory: ROOT.TDirectory, /, name: str) -> dict[str, Any]:
+    """
+    Read a histogram from a ROOT directory.
+    """
+    with ROOT.RNTupleReader.Open(directory.Get(name)) as reader:
+        entry = reader.CreateEntry()
+        reader.LoadEntry(0, entry)
+        object_hook = functools.partial(_object_hook, entry=entry)
+        output: dict[str, Any] = json.loads(str(entry["uhi"]), object_hook=object_hook)
+    _check_uhi_schema_version(output["uhi_schema"])
+
+    # Arrays are stored flattened; the shape is recovered from the axes
+    storage = output["storage"]
+    if "index" in storage:
+        storage["index"] = storage["index"].reshape(len(output["axes"]), -1)
+    elif output["axes"]:
+        shape = [_compute_axis_length(axis) for axis in output["axes"]]
+        for key in ARRAY_KEYS & storage.keys():
+            storage[key] = storage[key].reshape(shape)
+    return output

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import importlib.metadata
+import json
+from pathlib import Path
+from typing import Any
+
 import numpy as np
+import packaging.version
 import pytest
+from helpers import convert_histogram_to_32bit
 from pytest import approx
 
+import uhi.io.json
+from uhi.io import to_sparse
 from uhi.numpy_plottable import ensure_plottable_histogram
 
 ROOT = pytest.importorskip("ROOT")
+uhi_io_root = pytest.importorskip("uhi.io.root")
+
+BHVERSION = packaging.version.Version(importlib.metadata.version("boost_histogram"))
 
 
 def test_root_imported() -> None:
@@ -39,4 +51,290 @@ def test_root_th2f_convert() -> None:
         th.GetBinError(i + 1, j + 1) == approx(ie)
         for i, row in enumerate(np.sqrt(var))
         for j, ie in enumerate(row)
+    )
+
+
+# Serialization
+
+
+def test_valid_json(valid: Path, tmp_path: Path, sparse: bool) -> None:
+    data = valid.read_text(encoding="utf-8")
+    hists = json.loads(data, object_hook=uhi.io.json.object_hook)
+    if sparse:
+        hists = {name: to_sparse(hist) for name, hist in hists.items()}
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        for name, hist in hists.items():
+            uhi_io_root.write(root_file, name, hist)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehists = {name: uhi_io_root.read(root_file, name) for name in hists}
+
+    assert hists.keys() == rehists.keys()
+
+    for name in hists:
+        hist = hists[name]
+        rehist = rehists[name]
+
+        # Check that the JSON representation is the same
+        data = json.dumps(hist, default=uhi.io.json.default, sort_keys=True)
+        redata = json.dumps(rehist, default=uhi.io.json.default, sort_keys=True)
+
+        redata = redata.replace(" ", "").replace("\n", "")
+        data = data.replace(" ", "").replace("\n", "")
+
+        assert redata == data
+
+
+def test_reg_load(tmp_path: Path, resources: Path) -> None:
+    data = resources / "valid/reg.json"
+    hists = json.loads(
+        data.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        for name, hist in hists.items():
+            uhi_io_root.write(root_file, name, hist)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehists = {name: uhi_io_root.read(root_file, name) for name in hists}
+
+        # One single-entry RNTuple per histogram
+        with ROOT.RNTupleReader.Open(root_file.Get("one")) as reader:
+            fields = {
+                field.GetFieldName()
+                for field in reader.GetDescriptor().GetTopLevelFields()
+            }
+            assert fields == {"uhi", "values"}
+            assert reader.GetNEntries() == 1
+            entry = reader.CreateEntry()
+            reader.LoadEntry(0, entry)
+            native_one = json.loads(str(entry["uhi"]))
+
+    assert native_one["storage"]["values"] == "values"
+
+    one = rehists["one"]
+    two = rehists["two"]
+
+    assert one["metadata"] == {"one": True, "two": 2, "three": "three"}
+
+    assert len(one["axes"]) == 1
+    assert one["axes"][0]["type"] == "regular"
+    assert one["axes"][0]["lower"] == pytest.approx(0)
+    assert one["axes"][0]["upper"] == pytest.approx(5)
+    assert one["axes"][0]["bins"] == 3
+    assert one["axes"][0]["underflow"]
+    assert one["axes"][0]["overflow"]
+    assert not one["axes"][0]["circular"]
+
+    assert one["storage"]["type"] == "int"
+    assert one["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5])
+
+    assert two["storage"]["type"] == "double"
+    assert two["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5, 6, 7])
+
+
+def test_two_variable_axes(tmp_path: Path) -> None:
+    """Two variable axes must not collide on their field names."""
+    edges_a = np.array([0.0, 1.0, 2.0, 3.0])
+    edges_b = np.array([0.0, 10.0, 20.0])
+
+    def axis(edges: np.ndarray) -> dict[str, Any]:
+        return {
+            "type": "variable",
+            "edges": edges,
+            "underflow": False,
+            "overflow": False,
+            "circular": False,
+        }
+
+    hist: dict[str, Any] = {
+        "uhi_schema": 1,
+        "axes": [axis(edges_a), axis(edges_b)],
+        "storage": {
+            "type": "double",
+            "values": np.arange(6, dtype=np.float64).reshape(3, 2),
+        },
+    }
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "h", hist)
+
+    # write() must not replace the caller's arrays with field names.
+    assert isinstance(hist["axes"][0]["edges"], np.ndarray)
+    assert isinstance(hist["storage"]["values"], np.ndarray)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file, "h")
+
+    assert rehist["axes"][0]["edges"] == pytest.approx(edges_a)
+    assert rehist["axes"][1]["edges"] == pytest.approx(edges_b)
+    assert rehist["storage"]["values"].shape == (3, 2)
+    assert rehist["storage"]["values"] == pytest.approx(hist["storage"]["values"])
+
+
+def test_subdirectory(tmp_path: Path, resources: Path) -> None:
+    data = resources / "valid/2d.json"
+    hists = json.loads(
+        data.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file.mkdir("sub"), "main", hists["main"])
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file.Get("sub"), "main")
+
+    assert rehist["storage"]["values"] == pytest.approx(
+        hists["main"]["storage"]["values"]
+    )
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+def test_convert_bh(tmp_path: Path) -> None:
+    import boost_histogram as bh
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 13, 10, __dict__={"name": "x"}), storage=bh.storage.Weight()
+    )
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "histogram", h)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file, "histogram")
+
+    h2 = bh.Histogram(rehist)
+
+    assert h == h2
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.7.2") > BHVERSION,
+    reason="Requires boost-histogram 1.7.2+ for keep_storage=False support",
+)
+def test_convert_bh_no_storage(tmp_path: Path) -> None:
+    """Test ROOT serialization with keep_storage=False (structure-only histograms)."""
+    import boost_histogram as bh
+    import boost_histogram.serialization
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 10, __dict__={"name": "x"}), storage=bh.storage.Weight()
+    )
+    h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+
+    uhi_dict = boost_histogram.serialization.to_uhi(h, keep_storage=False)
+    assert uhi_dict["storage"]["type"] == "weighted"
+    assert "values" not in uhi_dict["storage"]
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "histogram", uhi_dict)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file, "histogram")
+
+    h2 = bh.Histogram(rehist)
+    assert h.axes == h2.axes
+    assert isinstance(h2.storage_type(), bh.storage.Weight)
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+def test_convert_hist(tmp_path: Path) -> None:
+    h: Any
+    try:
+        import hist
+
+        h = hist.Hist(
+            hist.axis.Regular(10, 0, 1, name="a", label="A"),
+            hist.axis.Integer(7, 13, overflow=False, name="b", label="B"),
+            storage=hist.storage.Weight(),
+            name="h",
+            label="H",
+        )
+    except ImportError:
+        # Fall back to boost-histogram (as in the ROOT CI environment)
+        import boost_histogram as bh
+
+        h = bh.Histogram(
+            bh.axis.Regular(10, 0, 1, __dict__={"name": "a", "label": "A"}),
+            bh.axis.Integer(
+                7, 13, overflow=False, __dict__={"name": "b", "label": "B"}
+            ),
+            storage=bh.storage.Weight(),
+        )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "histogram", h)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file, "histogram")
+    h2 = type(h)(rehist)
+    assert h == h2
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param("int", id="int_storage"),
+        pytest.param("double", id="double_storage"),
+        pytest.param("weighted", id="weighted_storage"),
+        pytest.param("mean", id="mean_storage"),
+    ],
+)
+def test_convert_bh_32bit_root(tmp_path: Path, storage_type: str) -> None:
+    """Test serialization of 32-bit histograms via ROOT."""
+    import boost_histogram as bh
+
+    axis = bh.axis.Regular(5, 0, 1, __dict__={"name": "x"})
+    h: Any
+
+    if storage_type == "int":
+        h = bh.Histogram(axis, storage=bh.storage.Int64())
+        for i in range(5):
+            h.fill([0.1 + i * 0.15] * 10)
+    elif storage_type == "double":
+        h = bh.Histogram(axis, storage=bh.storage.Double())
+        h.fill([0.1, 0.3, 0.5, 0.7, 0.9])
+    elif storage_type == "weighted":
+        h = bh.Histogram(axis, storage=bh.storage.Weight())
+        h.fill([0.1, 0.3, 0.5], weight=[1.5, 2.5, 3.5])
+    elif storage_type == "mean":
+        h = bh.Histogram(axis, storage=bh.storage.Mean())
+        h.fill([0.1, 0.3, 0.5], sample=[10.0, 20.0, 30.0])
+    else:
+        msg = f"Unknown storage type: {storage_type}"
+        raise ValueError(msg)
+
+    uhi_32bit = convert_histogram_to_32bit(h._to_uhi_())
+
+    tmp_file = tmp_path / "test_32bit.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "histogram", uhi_32bit)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist_32bit = uhi_io_root.read(root_file, "histogram")
+
+    # The 32-bit dtypes are preserved by the field types
+    assert rehist_32bit["storage"]["type"] == storage_type
+    assert (
+        rehist_32bit["storage"]["values"].dtype == uhi_32bit["storage"]["values"].dtype
+    )
+    assert rehist_32bit["storage"]["values"] == pytest.approx(
+        uhi_32bit["storage"]["values"]
     )

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,7 +12,7 @@ from helpers import convert_histogram_to_32bit
 from pytest import approx
 
 import uhi.io.json
-from uhi.io import to_sparse
+from uhi.io import ARRAY_KEYS, to_sparse
 from uhi.numpy_plottable import ensure_plottable_histogram
 
 ROOT = pytest.importorskip("ROOT")
@@ -134,6 +134,43 @@ def test_reg_load(tmp_path: Path, resources: Path) -> None:
 
     assert two["storage"]["type"] == "double"
     assert two["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5, 6, 7])
+
+
+@pytest.mark.parametrize("value", ["description", "values", "axis_0_edges"])
+def test_metadata_array_keys(tmp_path: Path, value: str) -> None:
+    metadata = dict.fromkeys(ARRAY_KEYS, value)
+    writer_info = {"test": metadata}
+    hist: dict[str, Any] = {
+        "uhi_schema": 1,
+        "metadata": metadata,
+        "writer_info": writer_info,
+        "axes": [
+            {
+                "type": "variable",
+                "edges": np.array([0.0, 1.0, 2.0]),
+                "underflow": False,
+                "overflow": False,
+                "circular": False,
+                "metadata": metadata,
+                "writer_info": writer_info,
+            }
+        ],
+        "storage": {"type": "double", "values": np.array([1.0, 2.0])},
+    }
+
+    tmp_file = tmp_path / "metadata.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        uhi_io_root.write(root_file, "histogram", hist)
+
+    with ROOT.TFile.Open(str(tmp_file)) as root_file:
+        rehist = uhi_io_root.read(root_file, "histogram")
+
+    assert rehist["metadata"] == metadata
+    assert rehist["writer_info"] == writer_info
+    assert rehist["axes"][0]["metadata"] == metadata
+    assert rehist["axes"][0]["writer_info"] == writer_info
+    assert rehist["axes"][0]["edges"] == pytest.approx(hist["axes"][0]["edges"])
+    assert rehist["storage"]["values"] == pytest.approx(hist["storage"]["values"])
 
 
 def test_two_variable_axes(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds `uhi.io.root`, a ROOT serialization backend alongside ZIP and HDF5, using ROOT's [RNTuple](https://root.cern/doc/master/classROOT_1_1RNTuple.html) API.

### Layout

One single-entry RNTuple per histogram written into any `TFile`:

- `uhi` (`std::string`): the IR string, arrays are replaced by the name of the field holding them.
- One flattened `std::vector<T>` field per array: storage arrays named after their key (`values`, `variances`, `counts`, `index`, ...), variable-axis edges as `axis_{i}_edges`.
- Dense shapes are recovered from the axes on read

### Usage

```python
with ROOT.TFile.Open("f.root", "RECREATE") as f:
    uhi.io.root.write(f, "h", h) # h has _to_uhi_ or is an IR dict

with ROOT.TFile.Open("f.root") as f:
    h2 = bh.Histogram(uhi.io.root.read(f, "h"))
    h3 = ROOT.TH2D(uhi.io.root.read(f, "h"))
```
```
# schema: a 2D histogram with 2 regular axes

************************************ NTUPLE ************************************
* N-Tuple : h                                                                  *
* Entries : 1                                                                  *
********************************************************************************
* Field 1       : uhi (std::string)                                            *
* Field 2       : variances (std::vector<double>)                              *
*   Field 2.1   : _0 (double)                                                  *
* Field 3       : values (std::vector<double>)                                 *
*   Field 3.1   : _0 (double)                                                  *
********************************************************************************
```