### PR TITLE
fix(io): only resolve array paths in storage and axes for zip

### DIFF
--- a/src/uhi/io/zip.py
+++ b/src/uhi/io/zip.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import json
 import zipfile
 from typing import Any
@@ -54,13 +53,13 @@ def write(
     zip_file.writestr(f"{name}.json", hist_json)
 
 
-def _object_hook(
-    dct: dict[str, Any], /, *, zip_file: zipfile.ZipFile
-) -> dict[str, Any]:
+def _load_arrays(dct: dict[str, Any], /, *, zip_file: zipfile.ZipFile) -> None:
+    """
+    Replace the stored paths with the arrays they point at, in-place.
+    """
     for item in ARRAY_KEYS & dct.keys():
         if isinstance(dct[item], str):
             dct[item] = np.load(zip_file.open(dct[item]))
-    return dct
 
 
 def read(zip_file: zipfile.ZipFile, /, name: str) -> dict[str, Any]:
@@ -68,8 +67,14 @@ def read(zip_file: zipfile.ZipFile, /, name: str) -> dict[str, Any]:
     Read histograms from a zip file.
     """
 
-    object_hook = functools.partial(_object_hook, zip_file=zip_file)
     with zip_file.open(f"{name}.json") as f:
-        output: dict[str, Any] = json.load(f, object_hook=object_hook)
-        _check_uhi_schema_version(output["uhi_schema"])
-        return output
+        output: dict[str, Any] = json.load(f)
+    _check_uhi_schema_version(output["uhi_schema"])
+
+    # Only storage and axes hold arrays; metadata and writer_info can contain
+    # any keys, including ones that look like array keys.
+    _load_arrays(output["storage"], zip_file=zip_file)
+    for axis in output["axes"]:
+        _load_arrays(axis, zip_file=zip_file)
+
+    return output

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -304,3 +304,37 @@ def test_convert_bh_32bit_zip(tmp_path: Path, storage_type: str) -> None:
     # Verify JSON representation is consistent
     redata = json.dumps(rehist_32bit, default=uhi.io.json.default)
     assert len(redata) > 0
+
+
+def test_metadata_with_array_key_names(tmp_path: Path) -> None:
+    """
+    Metadata keys can collide with array key names; they must not be treated
+    as references to stored arrays.
+    """
+    hist: Any = {
+        "uhi_schema": 1,
+        "metadata": {"values": "description", "edges": [1, 2, 3]},
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": 1.0,
+                "bins": 1,
+                "underflow": False,
+                "overflow": False,
+                "circular": False,
+                "metadata": {"counts": "label"},
+            }
+        ],
+        "storage": {"type": "int", "values": np.array([1])},
+    }
+
+    tmp_file = tmp_path / "meta.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        uhi.io.zip.write(zip_file, "h", hist)
+    with zipfile.ZipFile(tmp_file, "r") as zip_file:
+        rehist = uhi.io.zip.read(zip_file, "h")
+
+    assert rehist["metadata"] == {"values": "description", "edges": [1, 2, 3]}
+    assert rehist["axes"][0]["metadata"] == {"counts": "label"}
+    np.testing.assert_array_equal(rehist["storage"]["values"], [1])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The zip reader used a JSON `object_hook`, which runs on every dict during parsing. A `metadata` or `writer_info` key that matched an array key name was treated as a path into the zip archive. For example `{"metadata": {"values": "description"}}` raised `KeyError` on read, and a value that happened to match a real stored path was silently replaced with an array.

`write()` only replaces arrays in `storage` and the axes, so `read()` now does the same: parse the JSON plainly, then resolve `.npy` paths in those two places only.

Found by @siliataider while working on the ROOT backend in #257, which used the same pattern.