### PR TITLE
feat(schema)!: accept a single histogram at the top level

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,11 +73,15 @@ repos:
       - id: check-readthedocs
       - id: check-github-workflows
       - id: check-metaschema
-        files: ^src/uhi/resources/histogram.schema.json$
+        files: ^src/uhi/resources/histograms?\.schema\.json$
       - id: check-jsonschema
         name: Validate Histogram examples
-        args: [--schemafile, src/uhi/resources/histogram.schema.json]
+        args: [--schemafile, src/uhi/resources/histograms.schema.json]
         files: ^tests/resources/valid/.*\.json
+      - id: check-jsonschema
+        name: Validate single Histogram examples
+        args: [--schemafile, src/uhi/resources/histogram.schema.json]
+        files: ^tests/resources/valid_single/.*\.json
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
     rev: 0cee1769d7b9f642b7545be04c079f94277d6833  # frozen: 2026.09.04

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -152,9 +152,14 @@ single histogram, and it is not present (or is a histogram) in a dictionary of
 histograms. The single form is the natural output of `json.dumps` on one
 histogram, and it matches the HDF5 layout, where each histogram is a group.
 
+Two schemas are provided. `histogram.schema.json` describes one histogram,
+the intermediate representation. `histograms.schema.json` describes a JSON
+file, in either form above, and refers to the first schema for each histogram.
+
 ```{versionadded} 1.2
 
-The single histogram form is accepted by the schema.
+The single histogram form is accepted, and the schema is split into
+`histogram.schema.json` (one histogram) and `histograms.schema.json` (a file).
 ```
 
 ## Sparse storage
@@ -211,6 +216,10 @@ with filename.open(encoding="utf-8") as f:
 
 uhi.schema.validate(data)
 ```
+
+`validate` checks a JSON file object, in either form. Use
+`uhi.schema.validate_histogram` to check a single histogram (the intermediate
+representation).
 
 Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
 and maybe more.
@@ -363,9 +372,12 @@ A typing helper for the intermediate representation, `HistogramIR`, is provided
 in `uhi.typing.serialization` as a `TypedDict`. The schema, provided in
 `resources` as `histogram.schema.json`, also allows strings for data members,
 since some formats (like ZIP) put data into an optimized location and specify a
-reference to them.
+reference to them. The JSON file schema, `histograms.schema.json`, wraps it.
 
 ### Rendered schema
+
+```{jsonschema} ../src/uhi/resources/histograms.schema.json
+```
 
 ```{jsonschema} ../src/uhi/resources/histogram.schema.json
 ```
@@ -373,7 +385,11 @@ reference to them.
 
 ### Full schema
 
-The full schema is below:
+The full schemas are below:
+
+```{literalinclude} ../src/uhi/resources/histograms.schema.json
+:language: json
+```
 
 ```{literalinclude} ../src/uhi/resources/histogram.schema.json
 :language: json

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -196,11 +196,22 @@ sparse histograms. Scalar histograms (with no axes) are always dense.
 
 ## CLI/API
 
-You can test a JSON file against the schema with the `uhi` command (also
-`python -m uhi`):
+You can test a file against the schema with the `uhi` command (also
+`python -m uhi`). The format is selected by the file suffix: `.json`, `.zip`,
+`.h5`/`.hdf5`/`.hdf` (needs the `hdf5` extra), or `.root` (needs ROOT). Every
+histogram in a zip file (each `*.json` entry), HDF5 file (each group with a
+`uhi_schema` attribute), or ROOT file (each RNTuple, searched recursively) is
+checked:
 
 ```console
-$ uhi validate some/file.json
+$ uhi validate some/file.json some/other.zip some/data.h5 some/data.root
+```
+
+For HDF5 and ROOT files, add `:path` to restrict the check to one group or
+directory inside the file, or to a single histogram:
+
+```console
+$ uhi validate some/data.h5:run1/results some/data.root:analysis/main
 ```
 
 ```{versionadded} 1.2
@@ -221,8 +232,12 @@ uhi.schema.validate(data)
 `uhi.schema.validate_histogram` to check a single histogram (the intermediate
 representation).
 
-Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
-and maybe more.
+`uhi.schema.load` reads any supported file into a JSON-compatible dict, with an
+optional `path` keyword for HDF5 and ROOT files:
+
+```python
+uhi.schema.validate(uhi.schema.load("data.root", path="analysis"))
+```
 
 
 ## Format specific details and helpers

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -123,12 +123,39 @@ For example, a histogram created with boost-histogram might contain:
 }
 ```
 
-There is one more required top-level key: `"uhi_schema"`, which must be set to
-1 currently. If there is a future revision with a backward incompatible change,
-this will be bumped to 2, and readers should always error on future schemas,
-and support all older schemas. This is hoped to be unlikely/rare, but this also
-serves as a check that this is in fact a uhi serialization object. Non-breaking
-changes like additions are allowed without bumping the schema.
+There is one more required key for each histogram: `"uhi_schema"`, which must
+be set to 1 currently. If there is a future revision with a backward
+incompatible change, this will be bumped to 2, and readers should always error
+on future schemas, and support all older schemas. This is hoped to be
+unlikely/rare, but this also serves as a check that this is in fact a uhi
+serialization object. Non-breaking changes like additions are allowed without
+bumping the schema.
+
+### Named and single histograms
+
+A file can hold either a dictionary of named histograms, or a single histogram
+stored directly at the top level:
+
+```json
+{
+  "one": { "uhi_schema": 1, "axes": ["..."], "storage": { "...": "..." } },
+  "two": { "uhi_schema": 1, "axes": ["..."], "storage": { "...": "..." } }
+}
+```
+
+```json
+{ "uhi_schema": 1, "axes": ["..."], "storage": { "...": "..." } }
+```
+
+Readers can tell the two forms apart by the `"axes"` key: it is a list in a
+single histogram, and it is not present (or is a histogram) in a dictionary of
+histograms. The single form is the natural output of `json.dumps` on one
+histogram, and it matches the HDF5 layout, where each histogram is a group.
+
+```{versionadded} 1.2
+
+The single histogram form is accepted by the schema.
+```
 
 ## Sparse storage
 
@@ -222,6 +249,8 @@ uhi_hist = json.loads(ob, object_hook=uhi.io.json.object_hook)
 Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
 representation,`ob` is a JSON string, and `uhi_hist` is an intermediate
 representation; you can pass it to `boost_histogram.Histogram` or `hist.Hist`.
+This stores a single histogram directly. To store several histograms in one
+file, pass a dictionary of histograms instead; both forms are valid.
 
 
 ### ZIP

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -147,9 +147,9 @@ stored directly at the top level:
 { "uhi_schema": 1, "axes": ["..."], "storage": { "...": "..." } }
 ```
 
-Readers can tell the two forms apart by the `"axes"` key: it is a list in a
-single histogram, and it is not present (or is a histogram) in a dictionary of
-histograms. The single form is the natural output of `json.dumps` on one
+Readers can tell the two forms apart by the `"uhi_schema"` key: it is present
+(and required) in a single histogram, and a histogram name is never
+`"uhi_schema"` in a dictionary of histograms. The single form is the natural output of `json.dumps` on one
 histogram, and it matches the HDF5 layout, where each histogram is a group.
 
 Two schemas are provided. `histogram.schema.json` describes one histogram,

--- a/src/uhi/__main__.py
+++ b/src/uhi/__main__.py
@@ -1,7 +1,8 @@
 """
 Command line interface for uhi.
 
-``uhi validate`` checks JSON files against the schema.
+``uhi validate`` checks histogram files (JSON, zip, HDF5, or ROOT) against the
+schema.
 """
 
 from __future__ import annotations
@@ -28,9 +29,15 @@ def main(argv: Sequence[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     validate_parser = subparsers.add_parser(
-        "validate", help="validate JSON histogram files against the schema"
+        "validate",
+        help="validate histogram files (JSON, zip, HDF5, or ROOT) against the schema",
     )
-    validate_parser.add_argument("files", nargs="+", help="JSON files")
+    validate_parser.add_argument(
+        "files",
+        nargs="+",
+        help="histogram files (.json, .zip, .h5, .root); use file.h5:group or "
+        "file.root:dir to select a group or directory inside the file",
+    )
     validate_parser.set_defaults(func=_validate)
 
     args = parser.parse_args(argv)

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -4,7 +4,7 @@
   "title": "Histogram",
   "description": "A single histogram, the intermediate representation (IR). See histograms.schema.json for the JSON file format.",
   "type": "object",
-  "required": ["axes", "storage"],
+  "required": ["uhi_schema", "axes", "storage"],
   "additionalProperties": false,
   "properties": {
     "uhi_schema": {

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -2,11 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/scikit-hep/uhi/main/src/uhi/resources/histogram.schema.json",
   "title": "Histogram",
+  "description": "Either a dictionary of named histograms, or a single histogram stored directly. A single histogram is detected by its `axes` list.",
   "type": "object",
-  "additionalProperties": false,
-  "patternProperties": {
-    ".+": {
+  "if": { "required": ["axes"], "properties": { "axes": { "type": "array" } } },
+  "then": { "$ref": "#/$defs/histogram" },
+  "else": {
+    "additionalProperties": false,
+    "patternProperties": { ".+": { "$ref": "#/$defs/histogram" } }
+  },
+  "$defs": {
+    "histogram": {
       "type": "object",
+      "description": "A single histogram.",
       "required": ["axes", "storage"],
       "additionalProperties": false,
       "properties": {
@@ -40,9 +47,7 @@
           ]
         }
       }
-    }
-  },
-  "$defs": {
+    },
     "supported_metadata": {
       "oneOf": [
         { "type": "string" },

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -2,52 +2,42 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/scikit-hep/uhi/main/src/uhi/resources/histogram.schema.json",
   "title": "Histogram",
-  "description": "Either a dictionary of named histograms, or a single histogram stored directly. A single histogram is detected by its `axes` list.",
+  "description": "A single histogram, the intermediate representation (IR). See histograms.schema.json for the JSON file format.",
   "type": "object",
-  "if": { "required": ["axes"], "properties": { "axes": { "type": "array" } } },
-  "then": { "$ref": "#/$defs/histogram" },
-  "else": {
-    "additionalProperties": false,
-    "patternProperties": { ".+": { "$ref": "#/$defs/histogram" } }
-  },
-  "$defs": {
-    "histogram": {
-      "type": "object",
-      "description": "A single histogram.",
-      "required": ["axes", "storage"],
-      "additionalProperties": false,
-      "properties": {
-        "uhi_schema": {
-          "const": 1,
-          "description": "The schema version number"
-        },
-        "writer_info": { "$ref": "#/$defs/writer_info" },
-        "metadata": { "$ref": "#/$defs/metadata" },
-        "axes": {
-          "type": "array",
-          "description": "A list of the axes of the histogram.",
-          "items": {
-            "oneOf": [
-              { "$ref": "#/$defs/regular_axis" },
-              { "$ref": "#/$defs/variable_axis" },
-              { "$ref": "#/$defs/category_str_axis" },
-              { "$ref": "#/$defs/category_int_axis" },
-              { "$ref": "#/$defs/boolean_axis" }
-            ]
-          }
-        },
-        "storage": {
-          "description": "The storage of the bins of the histogram.",
-          "oneOf": [
-            { "$ref": "#/$defs/int_storage" },
-            { "$ref": "#/$defs/double_storage" },
-            { "$ref": "#/$defs/weighted_storage" },
-            { "$ref": "#/$defs/mean_storage" },
-            { "$ref": "#/$defs/weighted_mean_storage" }
-          ]
-        }
+  "required": ["axes", "storage"],
+  "additionalProperties": false,
+  "properties": {
+    "uhi_schema": {
+      "const": 1,
+      "description": "The schema version number"
+    },
+    "writer_info": { "$ref": "#/$defs/writer_info" },
+    "metadata": { "$ref": "#/$defs/metadata" },
+    "axes": {
+      "type": "array",
+      "description": "A list of the axes of the histogram.",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/regular_axis" },
+          { "$ref": "#/$defs/variable_axis" },
+          { "$ref": "#/$defs/category_str_axis" },
+          { "$ref": "#/$defs/category_int_axis" },
+          { "$ref": "#/$defs/boolean_axis" }
+        ]
       }
     },
+    "storage": {
+      "description": "The storage of the bins of the histogram.",
+      "oneOf": [
+        { "$ref": "#/$defs/int_storage" },
+        { "$ref": "#/$defs/double_storage" },
+        { "$ref": "#/$defs/weighted_storage" },
+        { "$ref": "#/$defs/mean_storage" },
+        { "$ref": "#/$defs/weighted_mean_storage" }
+      ]
+    }
+  },
+  "$defs": {
     "supported_metadata": {
       "oneOf": [
         { "type": "string" },

--- a/src/uhi/resources/histograms.schema.json
+++ b/src/uhi/resources/histograms.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Histograms",
-  "description": "A JSON file holding either a dictionary of named histograms, or a single histogram stored directly. A single histogram is detected by its `axes` list. Each histogram follows histogram.schema.json.",
+  "description": "A JSON file holding either a dictionary of named histograms, or a single histogram stored directly. A single histogram is detected by its `uhi_schema` key. Each histogram follows histogram.schema.json.",
   "type": "object",
-  "if": { "required": ["axes"], "properties": { "axes": { "type": "array" } } },
+  "if": { "required": ["uhi_schema"] },
   "then": { "$ref": "histogram.schema.json" },
   "else": {
     "additionalProperties": false,

--- a/src/uhi/resources/histograms.schema.json
+++ b/src/uhi/resources/histograms.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Histograms",
+  "description": "A JSON file holding either a dictionary of named histograms, or a single histogram stored directly. A single histogram is detected by its `axes` list. Each histogram follows histogram.schema.json.",
+  "type": "object",
+  "if": { "required": ["axes"], "properties": { "axes": { "type": "array" } } },
+  "then": { "$ref": "histogram.schema.json" },
+  "else": {
+    "additionalProperties": false,
+    "patternProperties": { ".+": { "$ref": "histogram.schema.json" } }
+  }
+}

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 import sys
+import zipfile
 from collections.abc import Callable
 from importlib import resources
 from pathlib import Path
@@ -12,7 +14,13 @@ _resources = resources.files("uhi") / "resources"
 histogram_file = _resources / "histogram.schema.json"
 histograms_file = _resources / "histograms.schema.json"
 
-__all__ = ["histogram_file", "histograms_file", "validate", "validate_histogram"]
+__all__ = [
+    "histogram_file",
+    "histograms_file",
+    "load",
+    "validate",
+    "validate_histogram",
+]
 
 
 def __dir__() -> list[str]:
@@ -49,6 +57,120 @@ def validate_histogram(data: dict[str, Any]) -> None:
     _compile("histogram.schema.json")(data)
 
 
+def _to_json_compatible(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert NumPy arrays and scalars so the schema validator can check them."""
+    from uhi.io.json import default  # noqa: PLC0415
+
+    result: dict[str, Any] = json.loads(json.dumps(data, default=default))
+    return result
+
+
+def _load_zip(path: Path) -> dict[str, Any]:
+    import uhi.io.zip  # noqa: PLC0415
+
+    with zipfile.ZipFile(path) as zip_file:
+        names = [n[:-5] for n in zip_file.namelist() if n.endswith(".json")]
+        return {name: uhi.io.zip.read(zip_file, name) for name in names}
+
+
+def _load_hdf5(path: Path, subpath: str | None) -> dict[str, Any]:
+    import h5py  # noqa: PLC0415
+
+    import uhi.io.hdf5  # noqa: PLC0415
+
+    hists: dict[str, Any] = {}
+
+    def visit(name: str, obj: Any) -> None:
+        if isinstance(obj, h5py.Group) and "uhi_schema" in obj.attrs:
+            hists[name] = uhi.io.hdf5.read(obj)
+
+    with h5py.File(path, "r") as h5_file:
+        start = h5_file[subpath] if subpath else h5_file
+        if "uhi_schema" in start.attrs:
+            return dict(uhi.io.hdf5.read(start))
+        start.visititems(visit)
+    return hists
+
+
+def _load_root(path: Path, subpath: str | None) -> dict[str, Any]:
+    import ROOT  # noqa: PLC0415
+
+    import uhi.io.root  # noqa: PLC0415
+
+    hists: dict[str, Any] = {}
+
+    def visit(directory: Any, prefix: str) -> None:
+        for key in directory.GetListOfKeys():
+            name = key.GetName()
+            match key.GetClassName():
+                case "ROOT::RNTuple" | "ROOT::Experimental::RNTuple":
+                    hists[f"{prefix}{name}"] = uhi.io.root.read(directory, name)
+                case "TDirectory" | "TDirectoryFile":
+                    visit(directory.Get(name), f"{prefix}{name}/")
+
+    root_file = ROOT.TFile.Open(str(path))
+    if not root_file:
+        msg = f"Could not open {path} as a ROOT file"
+        raise OSError(msg)
+    with root_file:
+        if not subpath:
+            visit(root_file, "")
+            return hists
+        parent, _, name = subpath.rstrip("/").rpartition("/")
+        directory = root_file.Get(parent) if parent else root_file
+        key = directory.GetKey(name) if directory else None
+        if not key:
+            msg = f"{subpath!r} not found in {path}"
+            raise KeyError(msg)
+        if key.GetClassName() in {"TDirectory", "TDirectoryFile"}:
+            visit(directory.Get(name), "")
+            return hists
+        # A single RNTuple
+        return uhi.io.root.read(directory, name)
+
+
+_SPEC_RE = re.compile(r"^(.+?\.(?:json|zip|h5|hdf5|hdf|root)):(.+)$", re.IGNORECASE)
+
+
+def _split_spec(spec: str) -> tuple[str, str | None]:
+    """Split ``file.root:dir/name`` into ``("file.root", "dir/name")``."""
+    if match := _SPEC_RE.match(spec):
+        return match[1], match[2]
+    return spec, None
+
+
+def load(file: str | Path, /, *, path: str | None = None) -> dict[str, Any]:
+    """
+    Load all histograms from a file as a ``{name: histogram}`` dict with
+    JSON-compatible values. The format is selected by suffix: ``.json``,
+    ``.zip``, ``.h5``/``.hdf5``/``.hdf``, or ``.root``.
+
+    For HDF5 and ROOT files, ``path`` restricts the search to a group or
+    directory inside the file. If it names a single histogram, that histogram
+    is returned instead of a dict.
+    """
+    filepath = Path(file)
+    match filepath.suffix.lower():
+        case ".h5" | ".hdf5" | ".hdf":
+            data = _load_hdf5(filepath, path)
+        case ".root":
+            data = _load_root(filepath, path)
+        case _ if path:
+            msg = (
+                f"An in-file path ({path!r}) is only supported for HDF5 and ROOT files"
+            )
+            raise ValueError(msg)
+        case ".json":
+            with filepath.open(encoding="utf-8") as f:
+                data = json.load(f)
+        case ".zip":
+            data = _load_zip(filepath)
+        case suffix:
+            msg = f"Unknown file format {suffix!r}, expected .json, .zip, .h5, or .root"
+            raise ValueError(msg)
+    return _to_json_compatible(data)
+
+
 def main(*files: str) -> None:
     """Validate histogram files."""
     import fastjsonschema  # noqa: PLC0415
@@ -56,12 +178,14 @@ def main(*files: str) -> None:
     retval = 0
 
     for file in files:
-        with Path(file).open(encoding="utf-8") as f:
-            data = json.load(f)
+        filename, path = _split_spec(file)
         try:
-            validate(data)
+            validate(load(filename, path=path))
         except fastjsonschema.JsonSchemaValueException as e:
             print(f"ERROR {file}: {e.message}")  # noqa: T201
+            retval = 1
+        except (OSError, ValueError, TypeError, KeyError, ImportError) as e:
+            print(f"ERROR {file}: {e}")  # noqa: T201
             retval = 1
         else:
             print(f"OK {file}")  # noqa: T201

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -8,27 +8,45 @@ from importlib import resources
 from pathlib import Path
 from typing import Any
 
-histogram_file = resources.files("uhi") / "resources/histogram.schema.json"
+_resources = resources.files("uhi") / "resources"
+histogram_file = _resources / "histogram.schema.json"
+histograms_file = _resources / "histograms.schema.json"
 
-__all__ = ["histogram_file", "validate"]
+__all__ = ["histogram_file", "histograms_file", "validate", "validate_histogram"]
 
 
 def __dir__() -> list[str]:
     return __all__
 
 
+def _load_local(uri: str) -> dict[str, Any]:
+    """Resolve a relative ``$ref`` to a schema shipped in ``resources``."""
+    with (_resources / uri).open(encoding="utf-8") as f:
+        return json.load(f)  # type: ignore[no-any-return]
+
+
 @functools.cache
-def _histogram_schema() -> Callable[[dict[str, Any]], None]:
+def _compile(name: str) -> Callable[[dict[str, Any]], None]:
     import fastjsonschema  # noqa: PLC0415
 
-    with histogram_file.open(encoding="utf-8") as f:
-        return fastjsonschema.compile(json.load(f))  # type: ignore[no-any-return]
+    with (_resources / name).open(encoding="utf-8") as f:
+        return fastjsonschema.compile(  # type: ignore[no-any-return]
+            json.load(f), handlers={"": _load_local}
+        )
 
 
 def validate(data: dict[str, Any]) -> None:
-    """Validate a histogram object against the schema."""
-    validator = _histogram_schema()
-    validator(data)
+    """
+    Validate a JSON file object against the schema.
+
+    This accepts a dictionary of named histograms or a single histogram.
+    """
+    _compile("histograms.schema.json")(data)
+
+
+def validate_histogram(data: dict[str, Any]) -> None:
+    """Validate a single histogram (the IR) against the schema."""
+    _compile("histogram.schema.json")(data)
 
 
 def main(*files: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ else:
 DIR = Path(__file__).parent.resolve()
 VALID_FILES = DIR.glob("resources/valid/*.json")
 INVALID_FILES = DIR.glob("resources/invalid/*.json")
+VALID_SINGLE_FILES = DIR.glob("resources/valid_single/*.json")
 
 
 @pytest.fixture(scope="session")
@@ -32,6 +33,12 @@ def valid(request: pytest.FixtureRequest) -> Path:
 
 @pytest.fixture(params=INVALID_FILES, ids=lambda p: p.name)
 def invalid(request: pytest.FixtureRequest) -> Path:
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture(params=VALID_SINGLE_FILES, ids=lambda p: p.name)
+def valid_single(request: pytest.FixtureRequest) -> Path:
+    """A single histogram stored directly, without a name."""
     return request.param  # type: ignore[no-any-return]
 
 

--- a/tests/resources/invalid/single_bad_axis.error.txt
+++ b/tests/resources/invalid/single_bad_axis.error.txt
@@ -1,0 +1,1 @@
+data.axes[0] must be valid exactly by one definition

--- a/tests/resources/invalid/single_bad_axis.json
+++ b/tests/resources/invalid/single_bad_axis.json
@@ -1,0 +1,5 @@
+{
+  "uhi_schema": 1,
+  "axes": [{ "type": "regular", "lower": 0, "upper": 5 }],
+  "storage": { "type": "int", "values": [1, 2, 3, 4, 5] }
+}

--- a/tests/resources/invalid/single_missing_storage.error.txt
+++ b/tests/resources/invalid/single_missing_storage.error.txt
@@ -1,0 +1,1 @@
+data must contain ['storage'] properties

--- a/tests/resources/invalid/single_missing_storage.json
+++ b/tests/resources/invalid/single_missing_storage.json
@@ -1,0 +1,14 @@
+{
+  "uhi_schema": 1,
+  "axes": [
+    {
+      "type": "regular",
+      "lower": 0,
+      "upper": 5,
+      "bins": 3,
+      "underflow": true,
+      "overflow": true,
+      "circular": false
+    }
+  ]
+}

--- a/tests/resources/valid_single/reg.json
+++ b/tests/resources/valid_single/reg.json
@@ -1,0 +1,16 @@
+{
+  "uhi_schema": 1,
+  "metadata": { "one": true, "two": 2, "three": "three" },
+  "axes": [
+    {
+      "type": "regular",
+      "lower": 0,
+      "upper": 5,
+      "bins": 3,
+      "underflow": true,
+      "overflow": true,
+      "circular": false
+    }
+  ],
+  "storage": { "type": "int", "values": [1, 2, 3, 4, 5] }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ from uhi.__main__ import main
 def test_cli_validate(resources: Path, capsys: pytest.CaptureFixture[str]) -> None:
     main(["validate", str(resources / "valid" / "reg.json")])
     assert capsys.readouterr().out.startswith("OK")
+    main(["validate", str(resources / "valid_single" / "reg.json")])
+    assert capsys.readouterr().out.startswith("OK")
     with pytest.raises(SystemExit):
         main(["validate", str(resources / "invalid" / "missing_axis.json")])
     assert capsys.readouterr().out.startswith("ERROR")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import json
+import zipfile
 from pathlib import Path
 
 import pytest
 
+import uhi.io.json
+import uhi.io.zip
+import uhi.schema
 from uhi.__main__ import main
 
 
@@ -14,4 +19,152 @@ def test_cli_validate(resources: Path, capsys: pytest.CaptureFixture[str]) -> No
     assert capsys.readouterr().out.startswith("OK")
     with pytest.raises(SystemExit):
         main(["validate", str(resources / "invalid" / "missing_axis.json")])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+def test_cli_validate_unknown_format(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "hist.txt"
+    bad.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        main(["validate", str(bad)])
+    assert "Unknown file format '.txt'" in capsys.readouterr().out
+
+
+def test_cli_validate_zip(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        for name, hist in hists.items():
+            uhi.io.zip.write(zip_file, name, hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_zip_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.zip"
+    with zipfile.ZipFile(tmp_file, "w") as zip_file:
+        for name, hist in hists.items():
+            uhi.io.zip.write(zip_file, name, hist)
+        # A bare JSON entry without the required keys
+        zip_file.writestr("broken.json", json.dumps({"uhi_schema": 1, "axes": []}))
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
+    out = capsys.readouterr().out
+    assert out.startswith("ERROR")
+    assert "storage" in out
+
+
+def test_cli_validate_hdf5(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        # Nest one level to check that groups are discovered recursively
+        grp = h5_file.create_group("nested")
+        for name, hist in hists.items():
+            uhi_io_hdf5.write(grp.create_group(name), hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_hdf5_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        for name, hist in hists.items():
+            grp = h5_file.create_group(name)
+            uhi_io_hdf5.write(grp, hist)
+            grp["storage"].attrs["type"] = "not_a_storage"
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("data.json", ("data.json", None)),
+        ("data.root:sub/dir", ("data.root", "sub/dir")),
+        ("some/dir/data.h5:grp", ("some/dir/data.h5", "grp")),
+        ("C:\\dir\\data.ROOT:grp", ("C:\\dir\\data.ROOT", "grp")),
+        ("C:\\dir\\data.root", ("C:\\dir\\data.root", None)),
+    ],
+)
+def test_split_spec(spec: str, expected: tuple[str, str | None]) -> None:
+    assert uhi.schema._split_spec(spec) == expected
+
+
+def test_cli_validate_path_unsupported(
+    resources: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit):
+        main(["validate", f"{resources / 'valid' / 'reg.json'}:main"])
+    assert "only supported for HDF5 and ROOT" in capsys.readouterr().out
+
+
+def test_cli_validate_hdf5_path(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    uhi_io_hdf5 = pytest.importorskip("uhi.io.hdf5")
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+    tmp_file = tmp_path / "test.h5"
+    with h5py.File(tmp_file, "w") as h5_file:
+        good = h5_file.create_group("good")
+        for name, hist in hists.items():
+            uhi_io_hdf5.write(good.create_group(name), hist)
+        bad = h5_file.create_group("bad")
+        for name, hist in hists.items():
+            grp = bad.create_group(name)
+            uhi_io_hdf5.write(grp, hist)
+            grp["storage"].attrs["type"] = "not_a_storage"
+
+    assert set(uhi.schema.load(tmp_file, path="good")) == set(hists)
+    assert set(uhi.schema.load(tmp_file, path="/good/")) == set(hists)
+    single = uhi.schema.load(tmp_file, path="good/one")
+    assert single["uhi_schema"] == 1
+
+    main(["validate", f"{tmp_file}:good", f"{tmp_file}:good/one"])
+    assert capsys.readouterr().out.count("OK") == 2
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:bad"])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:missing"])
     assert capsys.readouterr().out.startswith("ERROR")

--- a/tests/test_histogram_schema.py
+++ b/tests/test_histogram_schema.py
@@ -16,6 +16,12 @@ def test_valid_schemas(valid: Path) -> None:
     uhi.schema.validate(data)
 
 
+def test_valid_single_schemas(valid_single: Path) -> None:
+    with valid_single.open(encoding="utf-8") as f:
+        data = json.load(f)
+    uhi.schema.validate(data)
+
+
 def test_invalid_schemas(invalid: Path) -> None:
     with invalid.open(encoding="utf-8") as f:
         data = json.load(f)

--- a/tests/test_histogram_schema.py
+++ b/tests/test_histogram_schema.py
@@ -43,3 +43,50 @@ def test_invalid_schemas(invalid: Path) -> None:
         fastjsonschema.exceptions.JsonSchemaException, match=re.escape(errmsg)
     ):
         uhi.schema.validate(data)
+
+
+def test_invalid_single_schemas(invalid: Path) -> None:
+    """Each named invalid fixture is also invalid as a single histogram."""
+    with invalid.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if "axes" in data:
+        pytest.skip("already a single histogram")
+    (name, hist), *_ = data.items()
+
+    errmsg = invalid.with_suffix(".error.txt").read_text(encoding="utf-8").strip()
+    errmsg = errmsg.replace(f"data.{name}", "data", 1)
+
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException, match=re.escape(errmsg)
+    ):
+        uhi.schema.validate(hist)
+
+
+def test_invalid_named_entry(resources: Path) -> None:
+    with resources.joinpath("valid/reg.json").open(encoding="utf-8") as f:
+        data = json.load(f)
+    del data["two"]["storage"]
+
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.two must contain ['storage'] properties"),
+    ):
+        uhi.schema.validate(data)
+
+
+def test_missing_uhi_schema() -> None:
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.bad must contain ['uhi_schema'] properties"),
+    ):
+        uhi.schema.validate(
+            {"bad": {"axes": [], "storage": {"type": "int", "values": [1]}}}
+        )
+
+
+def test_named_entry_not_object() -> None:
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.bad must be object"),
+    ):
+        uhi.schema.validate({"bad": 1})

--- a/tests/test_histogram_schema.py
+++ b/tests/test_histogram_schema.py
@@ -20,6 +20,14 @@ def test_valid_single_schemas(valid_single: Path) -> None:
     with valid_single.open(encoding="utf-8") as f:
         data = json.load(f)
     uhi.schema.validate(data)
+    uhi.schema.validate_histogram(data)
+
+
+def test_named_not_a_histogram(valid: Path) -> None:
+    with valid.open(encoding="utf-8") as f:
+        data = json.load(f)
+    with pytest.raises(fastjsonschema.exceptions.JsonSchemaException):
+        uhi.schema.validate_histogram(data)
 
 
 def test_invalid_schemas(invalid: Path) -> None:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,6 +28,17 @@ def test_valid_json(valid: Path) -> None:
     assert hist.keys() == rehist.keys()
 
 
+def test_valid_single_json(valid_single: Path) -> None:
+    data = valid_single.read_text(encoding="utf-8")
+    hist = json.loads(data, object_hook=uhi.io.json.object_hook)
+    redata = json.dumps(hist, default=uhi.io.json.default)
+
+    assert redata.replace(" ", "").replace("\n", "") == data.replace(" ", "").replace(
+        "\n", ""
+    )
+    assert hist["storage"]["values"] == pytest.approx([1, 2, 3, 4, 5])
+
+
 def test_reg_load(resources: Path) -> None:
     data = resources / "valid/reg.json"
     hists = json.loads(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -10,6 +10,7 @@ import pytest
 from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
+import uhi.schema
 
 BHVERSION = packaging.version.Version(importlib.metadata.version("boost_histogram"))
 HISTVERSION = packaging.version.Version(importlib.metadata.version("hist"))
@@ -235,3 +236,24 @@ def test_convert_bh_32bit(storage_type: str) -> None:
     # Verify values can be serialized again without error
     redata2 = json.dumps(rehist_32bit, default=uhi.io.json.default)
     assert len(redata2) > 0
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+def test_named_round_trip() -> None:
+    import boost_histogram as bh
+
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Weight())
+    h1.fill([0.1, 0.5], weight=[2, 3])
+    h2 = bh.Histogram(bh.axis.Integer(0, 4), bh.axis.Boolean())
+    h2.fill([1, 2], [True, False])
+
+    data = json.dumps({"a": h1, "b": h2}, default=uhi.io.json.default)
+    uhi.schema.validate(json.loads(data))
+
+    rehists = json.loads(data, object_hook=uhi.io.json.object_hook)
+    assert rehists.keys() == {"a", "b"}
+    assert bh.Histogram(rehists["a"]) == h1
+    assert bh.Histogram(rehists["b"]) == h2

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,6 +12,7 @@ from helpers import convert_histogram_to_32bit
 from pytest import approx
 
 import uhi.io.json
+import uhi.schema
 from uhi.io import ARRAY_KEYS, to_sparse
 from uhi.numpy_plottable import ensure_plottable_histogram
 
@@ -375,3 +376,84 @@ def test_convert_bh_32bit_root(tmp_path: Path, storage_type: str) -> None:
     assert rehist_32bit["storage"]["values"] == pytest.approx(
         uhi_32bit["storage"]["values"]
     )
+
+
+# CLI
+
+
+def test_cli_validate_root(
+    valid: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        valid.read_text(encoding="utf-8"), object_hook=uhi.io.json.object_hook
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        # Nest one level to check that directories are searched recursively
+        directory = root_file.mkdir("nested")
+        for name, hist in hists.items():
+            uhi_io_root.write(directory, name, hist)
+
+    main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("OK")
+
+
+def test_cli_validate_root_invalid(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        for name, hist in hists.items():
+            hist = dict(hist)  # noqa: PLW2901
+            hist["storage"] = {**hist["storage"], "type": "not_a_storage"}
+            uhi_io_root.write(root_file, name, hist)
+
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_file)])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+
+def test_cli_validate_root_path(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from uhi.__main__ import main
+
+    hists = json.loads(
+        (resources / "valid" / "reg.json").read_text(encoding="utf-8"),
+        object_hook=uhi.io.json.object_hook,
+    )
+
+    tmp_file = tmp_path / "test.root"
+    with ROOT.TFile.Open(str(tmp_file), "RECREATE") as root_file:
+        good = root_file.mkdir("good")
+        bad = root_file.mkdir("bad")
+        for name, hist in hists.items():
+            uhi_io_root.write(good, name, hist)
+            broken = {**hist, "storage": {**hist["storage"], "type": "not_a_storage"}}
+            uhi_io_root.write(bad, name, broken)
+
+    assert set(uhi.schema.load(tmp_file, path="good")) == set(hists)
+    assert set(uhi.schema.load(tmp_file, path="good/")) == set(hists)
+    single = uhi.schema.load(tmp_file, path="good/one")
+    assert single["uhi_schema"] == 1
+
+    main(["validate", f"{tmp_file}:good", f"{tmp_file}:good/one"])
+    assert capsys.readouterr().out.count("OK") == 2
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:bad"])
+    assert capsys.readouterr().out.startswith("ERROR")
+
+    with pytest.raises(SystemExit):
+        main(["validate", f"{tmp_file}:missing"])
+    assert capsys.readouterr().out.startswith("ERROR")


### PR DESCRIPTION
CC @alexander-held.

This splits the schema for the IR (current file) and for a JSON file (new schema).

* We can add the missing `$id` after merging.
* This is a breaking change if someone is using the schema file directly.

:robot: _AI text below_ :robot:

The JSON helpers (`uhi.io.json.default`/`object_hook`) and the example in the serialization docs already store one histogram directly, without a name, but the schema only accepted a dictionary of named histograms, so `uhi validate` rejected such files.

The schema is now split in two:

- `histogram.schema.json` describes one histogram, matching `HistogramIR`. This is what a ZIP `.json` member or an HDF5 group holds.
- `histograms.schema.json` describes a JSON file: an object with an `axes` list is validated as a single histogram, anything else as a dictionary of named histograms. It uses a relative `$ref` to the first schema.

`uhi.schema.validate` checks a file object in either form, so existing callers are unaffected. `uhi.schema.validate_histogram` checks one histogram. Error messages for the named form are unchanged.

Docs get a "Named and single histograms" section and render both schemas. Tests add a `valid_single` fixture directory, two invalid single-histogram cases, and a check that a named file is rejected by the IR schema. The pre-commit `check-jsonschema` hooks cover both schemas.
