### PR TITLE
fix(json): support {name: histogram} mapping documents

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -185,6 +185,12 @@ with filename.open(encoding="utf-8") as f:
 uhi.schema.validate(data)
 ```
 
+A JSON document is either one histogram (an object with a `"uhi_schema"` key)
+or an object mapping names to histograms. Both the command and
+`uhi.schema.validate` accept both forms. For a mapping, each entry is validated
+and an error names the failing entry, such as `data.two must contain ['axes']
+properties`.
+
 Eventually this should also be usable for JSON's inside zip, HDF5 attributes,
 and maybe more.
 
@@ -222,6 +228,15 @@ uhi_hist = json.loads(ob, object_hook=uhi.io.json.object_hook)
 Above, `h` is a histogram that supports `_to_uhi_` or an intermediate
 representation,`ob` is a JSON string, and `uhi_hist` is an intermediate
 representation; you can pass it to `boost_histogram.Histogram` or `hist.Hist`.
+
+A JSON document can also be an object mapping names to histograms. The same
+helpers work with a dictionary of histograms:
+
+```python
+ob = json.dumps({"one": h1, "two": h2}, default=uhi.io.json.default)
+uhi_hists = json.loads(ob, object_hook=uhi.io.json.object_hook)
+h1_again = boost_histogram.Histogram(uhi_hists["one"])
+```
 
 
 ### ZIP
@@ -334,7 +349,9 @@ A typing helper for the intermediate representation, `HistogramIR`, is provided
 in `uhi.typing.serialization` as a `TypedDict`. The schema, provided in
 `resources` as `histogram.schema.json`, also allows strings for data members,
 since some formats (like ZIP) put data into an optimized location and specify a
-reference to them.
+reference to them. The top level of the schema accepts either one histogram or
+an object mapping names to histograms; the histogram itself is defined in
+`$defs/histogram`.
 
 ### Rendered schema
 

--- a/src/uhi/resources/histogram.schema.json
+++ b/src/uhi/resources/histogram.schema.json
@@ -2,12 +2,23 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/scikit-hep/uhi/main/src/uhi/resources/histogram.schema.json",
   "title": "Histogram",
-  "type": "object",
-  "additionalProperties": false,
-  "patternProperties": {
-    ".+": {
+  "description": "A single histogram, or an object mapping names to histograms.",
+  "oneOf": [
+    { "$ref": "#/$defs/histogram" },
+    {
       "type": "object",
-      "required": ["axes", "storage"],
+      "description": "An object mapping names to histograms.",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".+": { "$ref": "#/$defs/histogram" }
+      }
+    }
+  ],
+  "$defs": {
+    "histogram": {
+      "description": "A single histogram.",
+      "type": "object",
+      "required": ["uhi_schema", "axes", "storage"],
       "additionalProperties": false,
       "properties": {
         "uhi_schema": {
@@ -40,9 +51,7 @@
           ]
         }
       }
-    }
-  },
-  "$defs": {
+    },
     "supported_metadata": {
       "oneOf": [
         { "type": "string" },

--- a/src/uhi/schema.py
+++ b/src/uhi/schema.py
@@ -18,17 +18,51 @@ def __dir__() -> list[str]:
 
 
 @functools.cache
-def _histogram_schema() -> Callable[[dict[str, Any]], None]:
+def _histogram_schema() -> Callable[[Any], None]:
+    """
+    Compile a validator for a single histogram.
+
+    The schema file accepts either one histogram or a mapping of names to
+    histograms. The mapping form is handled in :func:`validate` so that errors
+    name the failing entry instead of the whole ``oneOf``.
+    """
     import fastjsonschema  # noqa: PLC0415
 
     with histogram_file.open(encoding="utf-8") as f:
-        return fastjsonschema.compile(json.load(f))  # type: ignore[no-any-return]
+        schema = json.load(f)
+
+    single = {"$ref": "#/$defs/histogram", "$defs": schema["$defs"]}
+    return fastjsonschema.compile(single)  # type: ignore[no-any-return]
 
 
 def validate(data: dict[str, Any]) -> None:
-    """Validate a histogram object against the schema."""
+    """
+    Validate a histogram object against the schema.
+
+    ``data`` is either a single histogram (has a ``uhi_schema`` key) or an
+    object mapping names to histograms.
+    """
+    import fastjsonschema  # noqa: PLC0415
+
     validator = _histogram_schema()
-    validator(data)
+
+    # Loaded JSON can be any type; let the validator report a non-object.
+    if not isinstance(data, dict) or "uhi_schema" in data:  # type: ignore[redundant-expr]
+        validator(data)
+        return
+
+    for name, hist in data.items():
+        try:
+            validator(hist)
+        except fastjsonschema.JsonSchemaValueException as e:
+            path = f"data.{name}{e.name.removeprefix('data')}"
+            raise fastjsonschema.JsonSchemaValueException(
+                e.message.replace(e.name, path, 1),
+                value=e.value,
+                name=path,
+                definition=e.definition,
+                rule=e.rule,
+            ) from None
 
 
 def main(*files: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -13,3 +14,22 @@ def test_cli_validate(resources: Path, capsys: pytest.CaptureFixture[str]) -> No
     with pytest.raises(SystemExit):
         main(["validate", str(resources / "invalid" / "missing_axis.json")])
     assert capsys.readouterr().out.startswith("ERROR")
+
+
+def test_cli_validate_single_and_mapping(
+    resources: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    hists = json.loads((resources / "valid" / "reg.json").read_text(encoding="utf-8"))
+    single = tmp_path / "single.json"
+    single.write_text(json.dumps(hists["one"]), encoding="utf-8")
+    main(["validate", str(single)])
+    assert capsys.readouterr().out.startswith("OK")
+
+    del hists["two"]["axes"]
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps(hists), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        main(["validate", str(bad)])
+    out = capsys.readouterr().out
+    assert out.startswith("ERROR")
+    assert "data.two must contain ['axes']" in out

--- a/tests/test_histogram_schema.py
+++ b/tests/test_histogram_schema.py
@@ -29,3 +29,54 @@ def test_invalid_schemas(invalid: Path) -> None:
         fastjsonschema.exceptions.JsonSchemaException, match=re.escape(errmsg)
     ):
         uhi.schema.validate(data)
+
+
+def test_valid_single_histogram(valid: Path) -> None:
+    with valid.open(encoding="utf-8") as f:
+        data = json.load(f)
+    for hist in data.values():
+        uhi.schema.validate(hist)
+
+
+def test_invalid_single_histogram(invalid: Path) -> None:
+    with invalid.open(encoding="utf-8") as f:
+        data = json.load(f)
+    (name, hist), *_ = data.items()
+
+    errmsg = invalid.with_suffix(".error.txt").read_text(encoding="utf-8").strip()
+    errmsg = errmsg.replace(f"data.{name}", "data", 1)
+
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException, match=re.escape(errmsg)
+    ):
+        uhi.schema.validate(hist)
+
+
+def test_invalid_mapping_names_entry(resources: Path) -> None:
+    with resources.joinpath("valid/reg.json").open(encoding="utf-8") as f:
+        data = json.load(f)
+    del data["two"]["storage"]
+
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.two must contain ['storage'] properties"),
+    ):
+        uhi.schema.validate(data)
+
+
+def test_missing_uhi_schema() -> None:
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.bad must contain ['uhi_schema'] properties"),
+    ):
+        uhi.schema.validate(
+            {"bad": {"axes": [], "storage": {"type": "int", "values": [1]}}}
+        )
+
+
+def test_mapping_value_not_object() -> None:
+    with pytest.raises(
+        fastjsonschema.exceptions.JsonSchemaException,
+        match=re.escape("data.bad must be object"),
+    ):
+        uhi.schema.validate({"bad": 1})

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -10,6 +10,7 @@ import pytest
 from helpers import convert_histogram_to_32bit
 
 import uhi.io.json
+import uhi.schema
 
 BHVERSION = packaging.version.Version(importlib.metadata.version("boost_histogram"))
 HISTVERSION = packaging.version.Version(importlib.metadata.version("hist"))
@@ -224,3 +225,25 @@ def test_convert_bh_32bit(storage_type: str) -> None:
     # Verify values can be serialized again without error
     redata2 = json.dumps(rehist_32bit, default=uhi.io.json.default)
     assert len(redata2) > 0
+
+
+@pytest.mark.skipif(
+    packaging.version.Version("1.6.1") > BHVERSION,
+    reason="Requires boost-histogram 1.6+",
+)
+def test_mapping_round_trip() -> None:
+    """A JSON document can map names to histogram objects."""
+    import boost_histogram as bh
+
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Weight())
+    h1.fill([0.1, 0.5], weight=[2, 3])
+    h2 = bh.Histogram(bh.axis.Integer(0, 4), bh.axis.Boolean())
+    h2.fill([1, 2], [True, False])
+
+    data = json.dumps({"a": h1, "b": h2}, default=uhi.io.json.default)
+    uhi.schema.validate(json.loads(data))
+
+    rehists = json.loads(data, object_hook=uhi.io.json.object_hook)
+    assert rehists.keys() == {"a", "b"}
+    assert bh.Histogram(rehists["a"]) == h1
+    assert bh.Histogram(rehists["b"]) == h2


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The JSON schema only accepted the `{name: histogram}` mapping form, so a single histogram document (a top-level object with `uhi_schema`) failed `uhi.schema.validate` and `uhi validate` with `data.uhi_schema must be object`.

- `histogram.schema.json`: the top level is now a `oneOf` of a single histogram or a mapping of names to histograms. The histogram definition moved to `$defs/histogram`, with `uhi_schema` now required. External tools (and the `check-jsonschema` hook) keep validating files of either form.
- `uhi.schema.validate`: compiles only the `$defs/histogram` definition and dispatches in Python on the `uhi_schema` key. Each mapping entry is validated separately, so errors name the entry (`data.two must contain ['axes'] properties`) instead of a generic `oneOf` failure.
- Docs: `docs/serialization.md` states that a JSON document is one histogram or a mapping of names to histograms, in the JSON, CLI, and schema sections.
- Tests: single-histogram validation from the existing fixtures, a mapping with one invalid entry, CLI on single and invalid mapping files, and a JSON round trip of a dict of boost-histogram objects.
